### PR TITLE
챌린지 생성 및 삭제 기능 구현

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/HimBackendApplication.java
+++ b/src/main/java/com/him/fpjt/him_backend/HimBackendApplication.java
@@ -1,9 +1,11 @@
 package com.him.fpjt.him_backend;
 
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@MapperScan(basePackages = "com.him.fpjt.him_backend.exercise.dao")
 public class HimBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/him/fpjt/him_backend/excercise/domain/ExcerciseType.java
+++ b/src/main/java/com/him/fpjt/him_backend/excercise/domain/ExcerciseType.java
@@ -1,5 +1,0 @@
-package com.him.fpjt.him_backend.excercise.domain;
-
-public enum ExcerciseType {
-    SQUAT, PUSHUP
-}

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
@@ -1,0 +1,34 @@
+package com.him.fpjt.him_backend.exercise.controller;
+
+import com.him.fpjt.him_backend.exercise.domain.Challenge;
+import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
+import com.him.fpjt.him_backend.exercise.service.ChallengeService;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/challenge")
+public class ChallengeController {
+    private ChallengeService challengeService;
+
+    public ChallengeController(ChallengeService challengeService) {
+        this.challengeService = challengeService;
+    }
+    @PostMapping
+    public ResponseEntity<String> createChallenge(@RequestBody Challenge challenge) {
+        System.out.println(challenge.toString());
+        boolean isSave = challengeService.createChallenge(challenge);
+        return isSave == true ?
+                ResponseEntity.status(HttpStatus.CREATED).build():
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("챌린지 저장에 실패했습니다.");
+    }
+}

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
@@ -31,4 +31,11 @@ public class ChallengeController {
                 ResponseEntity.status(HttpStatus.CREATED).build():
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("챌린지 저장에 실패했습니다.");
     }
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> removeChallenge(@PathVariable("id") long id) {
+        boolean isRemoved = challengeService.removeChallenge(id);
+        return isRemoved == true ?
+                ResponseEntity.ok().build() :
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("삭제할 챌린지가 없습니다.");
+    }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
@@ -25,7 +25,6 @@ public class ChallengeController {
     }
     @PostMapping
     public ResponseEntity<String> createChallenge(@RequestBody Challenge challenge) {
-        System.out.println(challenge.toString());
         boolean isSave = challengeService.createChallenge(challenge);
         return isSave == true ?
                 ResponseEntity.status(HttpStatus.CREATED).build():

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
@@ -1,0 +1,18 @@
+package com.him.fpjt.him_backend.exercise.dao;
+
+import com.him.fpjt.him_backend.exercise.domain.Challenge;
+import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
+import java.util.List;
+import java.util.Map;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.Results;
+
+public interface ChallengeDao {
+    public int insertChallenge(Challenge challenge);
+
+    public List<Challenge> selectOngoingChallenges(Map map);
+    public List<Challenge> selectDoneChallenges(long userId);
+    public Challenge selectChallenge(long id);
+    public int deleteChallenge(long id);
+}

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
@@ -1,18 +1,12 @@
 package com.him.fpjt.him_backend.exercise.dao;
 
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
-import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
 import java.util.List;
 import java.util.Map;
-import org.apache.ibatis.annotations.Param;
-import org.apache.ibatis.annotations.Result;
-import org.apache.ibatis.annotations.Results;
 
 public interface ChallengeDao {
     public int insertChallenge(Challenge challenge);
-
-    public List<Challenge> selectOngoingChallenges(Map map);
-    public List<Challenge> selectDoneChallenges(long userId);
-    public Challenge selectChallenge(long id);
+    
     public int deleteChallenge(long id);
+    public int deleteTodayChallengeByChallengeId(long id);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/domain/Challenge.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/domain/Challenge.java
@@ -1,4 +1,4 @@
-package com.him.fpjt.him_backend.excercise.domain;
+package com.him.fpjt.him_backend.exercise.domain;
 
 import java.time.LocalDate;
 import lombok.Getter;
@@ -9,14 +9,15 @@ import lombok.ToString;
 public class Challenge {
     private long id;
     private ChallengeStatus status;
-    private ExcerciseType type;
+    private ExerciseType type;
     private LocalDate startDt;
     private LocalDate endDt;
     private long goalCnt;
     private int achievedCnt;
     private long userId;
 
-    public Challenge(ChallengeStatus status, ExcerciseType type, LocalDate startDt, LocalDate endDt,
+    public Challenge(ChallengeStatus status, ExerciseType type,
+            LocalDate startDt, LocalDate endDt,
             long goalCnt, long userId) {
         this.status = status;
         this.type = type;

--- a/src/main/java/com/him/fpjt/him_backend/exercise/domain/ChallengeStatus.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/domain/ChallengeStatus.java
@@ -1,5 +1,7 @@
-package com.him.fpjt.him_backend.excercise.domain;
+package com.him.fpjt.him_backend.exercise.domain;
 
 public enum ChallengeStatus {
     PENDING, ONGOING, DONE
+
 }
+

--- a/src/main/java/com/him/fpjt/him_backend/exercise/domain/DifficultyLevel.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/domain/DifficultyLevel.java
@@ -1,4 +1,4 @@
-package com.him.fpjt.him_backend.excercise.domain;
+package com.him.fpjt.him_backend.exercise.domain;
 
 public enum DifficultyLevel {
     BASIC, INTERMIDIATE, HARD

--- a/src/main/java/com/him/fpjt/him_backend/exercise/domain/ExerciseType.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/domain/ExerciseType.java
@@ -1,0 +1,5 @@
+package com.him.fpjt.him_backend.exercise.domain;
+
+public enum ExerciseType {
+    SQUAT, PUSHUP
+}

--- a/src/main/java/com/him/fpjt/him_backend/exercise/domain/Game.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/domain/Game.java
@@ -1,4 +1,4 @@
-package com.him.fpjt.him_backend.excercise.domain;
+package com.him.fpjt.him_backend.exercise.domain;
 
 import java.time.LocalDate;
 import lombok.Getter;
@@ -9,16 +9,16 @@ import lombok.ToString;
 public class Game {
     private long id;
     private LocalDate date;
-    private ExcerciseType type;
+    private ExerciseType type;
     private DifficultyLevel difficultyLevel;
-    private boolean isAchived;
+    private boolean isAchieved;
     private long userId;
 
-    public Game(ExcerciseType type, DifficultyLevel difficultyLevel, boolean isAchived,
+    public Game(ExerciseType type, DifficultyLevel difficultyLevel, boolean isAchieved,
             long userId) {
         this.type = type;
         this.difficultyLevel = difficultyLevel;
-        this.isAchived = isAchived;
+        this.isAchieved = isAchieved;
         this.userId = userId;
         this.date = LocalDate.now();
     }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/domain/TodayChallenge.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/domain/TodayChallenge.java
@@ -1,10 +1,12 @@
 package com.him.fpjt.him_backend.exercise.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
 @ToString
 @Getter
+@AllArgsConstructor
 public class TodayChallenge {
     private long id;
     private long cnt;

--- a/src/main/java/com/him/fpjt/him_backend/exercise/domain/TodayChallenge.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/domain/TodayChallenge.java
@@ -1,4 +1,4 @@
-package com.him.fpjt.him_backend.excercise.domain;
+package com.him.fpjt.him_backend.exercise.domain;
 
 import lombok.Getter;
 import lombok.ToString;

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
@@ -1,0 +1,6 @@
+package com.him.fpjt.him_backend.exercise.service;
+
+import com.him.fpjt.him_backend.exercise.domain.Challenge;
+public interface ChallengeService {
+    public boolean createChallenge(Challenge challenge);
+}

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
@@ -1,6 +1,8 @@
 package com.him.fpjt.him_backend.exercise.service;
 
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
+
 public interface ChallengeService {
     public boolean createChallenge(Challenge challenge);
+    public boolean removeChallenge(long id);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
@@ -2,8 +2,10 @@ package com.him.fpjt.him_backend.exercise.service;
 
 import com.him.fpjt.him_backend.exercise.dao.ChallengeDao;
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
+import org.springframework.transaction.annotation.Transactional;
+@Slf4j
 @Service
 public class ChallengeServiceImpl implements ChallengeService {
     private ChallengeDao challengeDao;
@@ -12,8 +14,16 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     @Override
+    @Transactional
     public boolean createChallenge(Challenge challenge) {
         return challengeDao.insertChallenge(challenge) > 0 ? true : false;
     }
 
+    @Override
+    @Transactional
+    public boolean removeChallenge(long id) {
+        challengeDao.deleteTodayChallengeByChallengeId(id);
+        log.info("delete todaychallenge by challengeId");
+        return challengeDao.deleteChallenge(id) > 0 ? true : false;
+    }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
@@ -1,0 +1,19 @@
+package com.him.fpjt.him_backend.exercise.service;
+
+import com.him.fpjt.him_backend.exercise.dao.ChallengeDao;
+import com.him.fpjt.him_backend.exercise.domain.Challenge;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ChallengeServiceImpl implements ChallengeService {
+    private ChallengeDao challengeDao;
+    public ChallengeServiceImpl(ChallengeDao challengeDao) {
+        this.challengeDao = challengeDao;
+    }
+
+    @Override
+    public boolean createChallenge(Challenge challenge) {
+        return challengeDao.insertChallenge(challenge) > 0 ? true : false;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,12 @@
 spring:
   profiles:
     active: local
+
+mybatis:
+  mapper-locations: mappers/*.xml
+  type-aliases-package: com.him.fpjt.him_backend.exercise.domain, com.him.fpjt.him_backend.user.domain
+  configuration:
+    log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
 ---
 spring:
   config:

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.him.fpjt.him_backend.exercise.dao.ChallengeDao">
+  <insert id="insertChallenge" parameterType="Challenge">
+    INSERT INTO challenge (status, type, start_dt, end_dt, goal_cnt, achieve_cnt, user_id)
+        VALUES (#{status}, #{type}, #{startDt}, #{endDt}, #{goalCnt}, #{achievedCnt}, #{userId})
+  </insert>
+  
+</mapper>

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -6,5 +6,10 @@
     INSERT INTO challenge (status, type, start_dt, end_dt, goal_cnt, achieve_cnt, user_id)
         VALUES (#{status}, #{type}, #{startDt}, #{endDt}, #{goalCnt}, #{achievedCnt}, #{userId})
   </insert>
-  
+  <delete id="deleteChallenge" parameterType="long">
+    DELETE FROM challenge WHERE id = #{id}
+  </delete>
+  <delete id="deleteTodayChallengeByChallengeId" parameterType="long">
+    DELETE FROM today_challenge WHERE challenge_id = #{id}
+  </delete>
 </mapper>

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
@@ -60,4 +60,20 @@ public class ChallegeServiceImplTest {
         when(challengeDao.insertChallenge(challenge)).thenReturn(0);
         assertFalse(challengeService.createChallenge(challenge));
     }
+
+    @Test
+    @DisplayName("챌린지 삭제 성공 시에 true를 반환한다.")
+    public void removeChallenge_success() {
+        when(challengeDao.deleteTodayChallengeByChallengeId(1L)).thenReturn(1);
+        when(challengeDao.deleteChallenge(1L)).thenReturn(1);
+        assertTrue(challengeService.removeChallenge(1L));
+    }
+
+    @Test
+    @DisplayName("챌린지 삭제 실패 시에 false를 반환한다.")
+    public void removeChallenge_fail() {
+        when(challengeDao.deleteTodayChallengeByChallengeId(1L)).thenReturn(1);
+        when(challengeDao.deleteChallenge(1L)).thenReturn(0);
+        assertFalse(challengeService.removeChallenge(1L));
+    }
 }

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
@@ -1,0 +1,63 @@
+package com.him.fpjt.him_backend.exercise.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.him.fpjt.him_backend.exercise.dao.ChallengeDao;
+import com.him.fpjt.him_backend.exercise.domain.Challenge;
+import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
+import com.him.fpjt.him_backend.exercise.domain.ExerciseType;
+import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ChallegeServiceImplTest {
+    @Mock
+    private ChallengeDao challengeDao;
+
+    @InjectMocks
+    private ChallengeServiceImpl challengeService;
+    private Challenge mockChallenge;
+    private TodayChallenge mockTodayChallenge;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        mockChallenge = new Challenge(
+                ChallengeStatus.ONGOING,
+                ExerciseType.SQUAT,
+                LocalDate.now(),
+                LocalDate.now(),
+                10L,
+                1L
+        );
+        mockTodayChallenge = new TodayChallenge(
+                mockChallenge.getId(),
+                10L,
+                1,
+                1L
+        );
+    }
+
+    @Test
+    @DisplayName("챌린지 생성 성공 시에 true를 반환한다.")
+    public void createChallenge_success() {
+        Challenge challenge = new Challenge(ChallengeStatus.ONGOING, ExerciseType.SQUAT, LocalDate.now(), LocalDate.now(), 10L, 1L);
+        when(challengeDao.insertChallenge(challenge)).thenReturn(1);
+        assertTrue(challengeService.createChallenge(challenge));
+    }
+
+    @Test
+    @DisplayName("챌린지 생성 실패 시에 false를 반환한다.")
+    public void createChallenge_fail() {
+        Challenge challenge = new Challenge(ChallengeStatus.ONGOING, ExerciseType.SQUAT, LocalDate.now(), LocalDate.now(), 10L, 1L);
+        when(challengeDao.insertChallenge(challenge)).thenReturn(0);
+        assertFalse(challengeService.createChallenge(challenge));
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

> resolve #10 

## 작업 내용

> mybatis와 swagger를 이용하여 챌린지 생성 및 삭제 기능 구현했습니다.
> - 생성 기능 : 운동과 시작일, 만료일, 목표 갯수 등을 받아 새 챌린지를 생성합니다.
> - 삭제 기능 : `Challenge` 데이터와 삭제할 챌린지의 하위테이블인 `TodayChallenge` 데이터를 삭제합니다.

## 리뷰 요구사항

> API와 Service 메서드의 경우, `create`, `remove`를 사용하여 사용자에게 친근한 네이밍하고자 하였습니다. 반면, DAO에서는 `insert`, `delete`와 같은 쿼리문과 유사한 네이밍을 사용하였습니다.
> 현재 단위 테스트는 `Service` 계층만 포함하였으며, 추후 `Controller` 계층의 테스트 코드도 작성할 예정입니다.
+ 후에 개선할 부분 ) 에러 공통 처리
