### PR TITLE
챌린지 조회 기능 구현

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
@@ -30,6 +30,13 @@ public class ChallengeController {
                 ResponseEntity.status(HttpStatus.CREATED).build():
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("챌린지 저장에 실패했습니다.");
     }
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getChallengeDetail(@PathVariable("id") long id) {
+        Challenge challenges = challengeService.getChallengeDetail(id);
+        return challenges != null ?
+                ResponseEntity.ok().body(challenges):
+                ResponseEntity.status(HttpStatus.NOT_FOUND).body("일치하는 챌린지가 없습니다.");
+    }
     @DeleteMapping("/{id}")
     public ResponseEntity<String> removeChallenge(@PathVariable("id") long id) {
         boolean isRemoved = challengeService.removeChallenge(id);

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
@@ -30,6 +30,20 @@ public class ChallengeController {
                 ResponseEntity.status(HttpStatus.CREATED).build():
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("챌린지 저장에 실패했습니다.");
     }
+    @GetMapping
+    public ResponseEntity<?> getChallengeByStatusAndUserId(@RequestParam("userId") long userId,
+                                                        @RequestParam("status") String status) {
+        ChallengeStatus challengeStatus;
+        try {
+            challengeStatus = ChallengeStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("잘못된 상태 값입니다.");
+        }
+        List<Challenge> challenges = challengeService.getChallengeByStatusAndUserId(userId, challengeStatus);
+        return challenges.isEmpty() ?
+                ResponseEntity.status(HttpStatus.NO_CONTENT).body("챌린지가 없습니다.") :
+                ResponseEntity.ok().body(challenges);
+    }
     @GetMapping("/{id}")
     public ResponseEntity<?> getChallengeDetail(@PathVariable("id") long id) {
         Challenge challenges = challengeService.getChallengeDetail(id);

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 public interface ChallengeDao {
     public int insertChallenge(Challenge challenge);
+    public List<Challenge> selectChallengesByStatusAndUserId(Map<String, Object> params);
     public Challenge selectChallenge(long id);
     public int deleteChallenge(long id);
     public int deleteTodayChallengeByChallengeId(long id);

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 public interface ChallengeDao {
     public int insertChallenge(Challenge challenge);
-    
+    public Challenge selectChallenge(long id);
     public int deleteChallenge(long id);
     public int deleteTodayChallengeByChallengeId(long id);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/domain/Challenge.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/domain/Challenge.java
@@ -1,11 +1,13 @@
 package com.him.fpjt.him_backend.exercise.domain;
 
 import java.time.LocalDate;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString
+@AllArgsConstructor
 public class Challenge {
     private long id;
     private ChallengeStatus status;

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
@@ -4,5 +4,6 @@ import com.him.fpjt.him_backend.exercise.domain.Challenge;
 
 public interface ChallengeService {
     public boolean createChallenge(Challenge challenge);
+    public Challenge getChallengeDetail(long id);
     public boolean removeChallenge(long id);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
@@ -1,9 +1,12 @@
 package com.him.fpjt.him_backend.exercise.service;
 
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
+import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
+import java.util.List;
 
 public interface ChallengeService {
     public boolean createChallenge(Challenge challenge);
+    public List<Challenge> getChallengeByStatusAndUserId(long userId, ChallengeStatus status);
     public Challenge getChallengeDetail(long id);
     public boolean removeChallenge(long id);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
@@ -2,6 +2,10 @@ package com.him.fpjt.him_backend.exercise.service;
 
 import com.him.fpjt.him_backend.exercise.dao.ChallengeDao;
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
+import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +22,15 @@ public class ChallengeServiceImpl implements ChallengeService {
     public boolean createChallenge(Challenge challenge) {
         return challengeDao.insertChallenge(challenge) > 0 ? true : false;
     }
+
+    @Override
+    public List<Challenge> getChallengeByStatusAndUserId(long userId, ChallengeStatus status) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("userId", userId);
+        params.put("status", ChallengeStatus.ONGOING.name());
+        return challengeDao.selectChallengesByStatusAndUserId(params);
+    }
+
     @Override
     public Challenge getChallengeDetail(long id) {
         return challengeDao.selectChallenge(id);

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
@@ -18,6 +18,10 @@ public class ChallengeServiceImpl implements ChallengeService {
     public boolean createChallenge(Challenge challenge) {
         return challengeDao.insertChallenge(challenge) > 0 ? true : false;
     }
+    @Override
+    public Challenge getChallengeDetail(long id) {
+        return challengeDao.selectChallenge(id);
+    }
 
     @Override
     @Transactional

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -6,6 +6,9 @@
     INSERT INTO challenge (status, type, start_dt, end_dt, goal_cnt, achieve_cnt, user_id)
         VALUES (#{status}, #{type}, #{startDt}, #{endDt}, #{goalCnt}, #{achievedCnt}, #{userId})
   </insert>
+  <select id="selectChallenge" parameterType="long" resultType="Challenge">
+    SELECT * FROM challenge WHERE id = #{id}
+  </select>
   <delete id="deleteChallenge" parameterType="long">
     DELETE FROM challenge WHERE id = #{id}
   </delete>

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -6,6 +6,17 @@
     INSERT INTO challenge (status, type, start_dt, end_dt, goal_cnt, achieve_cnt, user_id)
         VALUES (#{status}, #{type}, #{startDt}, #{endDt}, #{goalCnt}, #{achievedCnt}, #{userId})
   </insert>
+  <select id="selectChallengesByStatusAndUserId" parameterType="map" resultType="Challenge">
+    SELECT * FROM challenge
+    <trim prefix="WHERE" prefixOverrides="AND | OR">
+        <if test="status != null and status != ''">
+          AND status = #{status}
+        </if>
+        <if test = "userId != null and userId != ''">
+            AND user_id = #{userId}
+        </if>
+    </trim>
+  </select>
   <select id="selectChallenge" parameterType="long" resultType="Challenge">
     SELECT * FROM challenge WHERE id = #{id}
   </select>


### PR DESCRIPTION
## 연관된 이슈

> resolve #14 

## 작업 내용

> 진행 중일 챌린지, 완료된 챌린지, 챌린지 id에 따른 챌린지 조회 기능을 추가하였습니다.
> - 상세 챌린지 조회 : `challengeId` 데이터 이용한 챌린지 조회
> - 진행 중인 챌린지 조회, 완료된 챌린지 조회 : `status`, `userId`에 따라 챌린지 목록 조회

### 스크린샷 (선택)

## 리뷰 요구사항 (선택)

> dao의 `selectChallengesByStatusAndUserId` 메서드의 경우 매개 변수가 `Map<String, Object>` 타입이라 dto를 생성하여 한번 감쌀지 그대로 둘지 고민입니다. 일단 이렇게 두고 status와 userId를 이용한 조회가 많을 경우 dto 적용을 고려해볼 생각인데 의견 어떠신지 궁금합니다.