### PR TITLE
조회 테스트 코드 추가 및 path variable 자원명 변경

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
@@ -3,6 +3,7 @@ package com.him.fpjt.him_backend.exercise.controller;
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
 import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
 import com.him.fpjt.him_backend.exercise.service.ChallengeService;
+import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,7 +32,7 @@ public class ChallengeController {
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("챌린지 저장에 실패했습니다.");
     }
     @GetMapping
-    public ResponseEntity<?> getChallengeByStatusAndUserId(@RequestParam("userId") long userId,
+    public ResponseEntity<?> getChallengeByStatusAndUserId(@RequestParam(value = "userId", defaultValue = "true") long userId,
                                                         @RequestParam("status") String status) {
         ChallengeStatus challengeStatus;
         try {
@@ -44,15 +45,15 @@ public class ChallengeController {
                 ResponseEntity.status(HttpStatus.NO_CONTENT).body("챌린지가 없습니다.") :
                 ResponseEntity.ok().body(challenges);
     }
-    @GetMapping("/{id}")
-    public ResponseEntity<?> getChallengeDetail(@PathVariable("id") long id) {
+    @GetMapping("/{challengeId}")
+    public ResponseEntity<?> getChallengeDetail(@PathVariable("challengeId") long id) {
         Challenge challenges = challengeService.getChallengeDetail(id);
         return challenges != null ?
                 ResponseEntity.ok().body(challenges):
                 ResponseEntity.status(HttpStatus.NOT_FOUND).body("일치하는 챌린지가 없습니다.");
     }
-    @DeleteMapping("/{id}")
-    public ResponseEntity<String> removeChallenge(@PathVariable("id") long id) {
+    @DeleteMapping("/{challengeId}")
+    public ResponseEntity<String> removeChallenge(@PathVariable("challengeId") long id) {
         boolean isRemoved = challengeService.removeChallenge(id);
         return isRemoved == true ?
                 ResponseEntity.ok().build() :

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
@@ -3,7 +3,6 @@ package com.him.fpjt.him_backend.exercise.controller;
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
 import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
 import com.him.fpjt.him_backend.exercise.service.ChallengeService;
-import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
@@ -68,6 +68,17 @@ public class ChallegeServiceImplTest {
     }
 
     @Test
+    @DisplayName("status와 userId에 따라 챌린지 목록을 조회한다.")
+    void getChallengeByStatusAndUserId() {
+        when(challengeDao.selectChallengesByStatusAndUserId(anyMap())).thenReturn(List.of(mockChallenge));
+
+        List<Challenge> challenges = challengeService.getChallengeByStatusAndUserId(1L, ChallengeStatus.ONGOING);
+
+        assertEquals(1, challenges.size());
+        verify(challengeDao, times(1)).selectChallengesByStatusAndUserId(anyMap());
+    }
+
+    @Test
     @DisplayName("챌린지 id에 따라 챌린지를 조회한다.")
     void getChallengeDetail() {
         when(challengeDao.selectChallenge(1L)).thenReturn(mockChallenge);

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
@@ -1,7 +1,12 @@
 package com.him.fpjt.him_backend.exercise.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.him.fpjt.him_backend.exercise.dao.ChallengeDao;
@@ -10,6 +15,7 @@ import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
 import com.him.fpjt.him_backend.exercise.domain.ExerciseType;
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -61,6 +67,16 @@ public class ChallegeServiceImplTest {
         assertFalse(challengeService.createChallenge(challenge));
     }
 
+    @Test
+    @DisplayName("챌린지 id에 따라 챌린지를 조회한다.")
+    void getChallengeDetail() {
+        when(challengeDao.selectChallenge(1L)).thenReturn(mockChallenge);
+
+        Challenge challenge = challengeService.getChallengeDetail(1L);
+
+        assertNotNull(challenge);
+        verify(challengeDao, times(1)).selectChallenge(1L);
+    }
     @Test
     @DisplayName("챌린지 삭제 성공 시에 true를 반환한다.")
     public void removeChallenge_success() {


### PR DESCRIPTION
## 작업 내용
> 프로젝트 브랜치가 조금 꼬여서 조회 테스트 코드와 이름 리펙토링에 대한 pr을 따로 생성하였습니다.

> 조회 service 메서드 테스트 코드를 추가하였습니다.
> 리뷰 내용에 따라 path variable 자원명을 변경하였습니다.
