### PR TITLE
feat : dao

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/HimBackendApplication.java
+++ b/src/main/java/com/him/fpjt/him_backend/HimBackendApplication.java
@@ -1,11 +1,16 @@
 package com.him.fpjt.him_backend;
 
 import org.mybatis.spring.annotation.MapperScan;
+import org.mybatis.spring.annotation.MapperScans;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 @MapperScan(basePackages = "com.him.fpjt.him_backend.exercise.dao")
+@MapperScans({
+		@MapperScan("com.him.fpjt.him_backend.exercise.dao"),
+		@MapperScan("com.him.fpjt.him_backend.user.dao")
+})
 public class HimBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/GameDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/GameDao.java
@@ -1,13 +1,19 @@
 package com.him.fpjt.him_backend.exercise.dao;
 
 import com.him.fpjt.him_backend.exercise.domain.Game;
-
+import java.time.LocalDate;
 import java.util.List;
+
+import com.him.fpjt.him_backend.exercise.domain.Game;
+import java.time.LocalDate;
 
 public interface GameDao {
 
-    public int insertGame(Game game);
+    int insertGame(Game game);
 
-    public int updateGame(int id);
+    Game findGameById(long gameId);
 
+    boolean existsAchievedGame(LocalDate date, String type, String difficultyLevel, long userId);
+
+    int updateGameAchievement(long id);
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
@@ -1,0 +1,10 @@
+package com.him.fpjt.him_backend.user.dao;
+
+import com.him.fpjt.him_backend.user.domain.User;
+
+import java.util.List;
+
+public interface UserDao {
+
+    int updateUserExp(long userId, long expPoints);
+}

--- a/src/main/resources/mappers/GameMapper.xml
+++ b/src/main/resources/mappers/GameMapper.xml
@@ -4,16 +4,33 @@
 
 <mapper namespace="com.him.fpjt.him_backend.exercise.dao.GameDao">
 
-    <!-- 게임 정보 삽입 -->
+    <!-- 새로운 게임을 삽입하는 SQL 구문 -->
     <insert id="insertGame" parameterType="Game">
-        INSERT INTO game
-        VALUES (#{date}, #{type}, #{difficulty_level}, false, #{userId})
+        INSERT INTO game (date, type, difficulty_level, is_achieved, user_id)
+        VALUES (#{date}, #{type}, #{difficultyLevel}, false, #{userId})
     </insert>
 
-    <!-- 성공 시, 게임 정보 수정 -->
-    <update id="updateGame" parameterType="int">
+    <!-- 특정 게임 ID로 게임 정보 조회 -->
+    <select id="findGameById" parameterType="long" resultType="Game">
+        SELECT * FROM game WHERE id = #{gameId}
+    </select>
+
+    <!-- 동일 날짜, 동일 유형, 동일 난이도에서 성공 처리된 게임이 있는지 확인 -->
+    <select id="existsAchievedGame" parameterType="map" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1 FROM game
+            WHERE DATE(date) = #{date}
+            AND type = #{type}
+            AND difficulty_level = #{difficultyLevel}
+            AND user_id = #{userId}
+            AND is_achieved = true
+        )
+    </select>
+
+    <!-- 특정 게임 ID로 성공 여부를 수정하는 SQL 구문 -->
+    <update id="updateGameAchievement" parameterType="long">
         UPDATE game
-        SET is_achieved=true
-        WHERE id=#{id}
+        SET is_achieved = true
+        WHERE id = #{id}
     </update>
 </mapper>

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.him.fpjt.him_backend.user.dao.UserDao">
+    <!-- 사용자의 경험치를 업데이트하는 SQL 구문 -->
+    <update id="updateUserExp" parameterType="map">
+        UPDATE user
+        SET exp = exp + #{expPoints}
+        WHERE id = #{userId}
+    </update>
+</mapper>


### PR DESCRIPTION
## 연관된 이슈

> #12 

## 작업 내용

> 현재 게임이 성공했을 때, 이것을 게임 테이블에서 조회하여 사용자의 경험치에 추가 여부를 결정하는 DAO와 Mapper 로직을 완성했습니다.

> 게임 테이블에서 날짜, 타입, 난이도, 성공 여부에 따라 게임을 조회하였고, 같은 게임 중 이미 성공한 게임이 있다면 사용자의 경험치를 추가하지 않고, 없다면 추가하는 로직을 GameDao와 GameMapper로 구현하였습니다.

> 사용자의 경험치를 추가할 때, 역할 분할을 위해 유저에 대한 로직처리를 게임에서 분리하여 UserDao와 UserMapper을 구현하였습니다.

> GameDao.java : findGameById - 현재 게임 찾기, existsAchievedGame - 현재 게임과 동일한 게임 중 성취한 게임이 있는가, updateGameAchievement - 게임 성취 반영
> GameMapper.xml : 위 3가지 경우의 sql문 작성
> UserDao.java : updateUserExp - 사용자 경험치 반영
> UserMapper.xml : 사용자 경험치를 반영하는 sql문 작성
> HimBackendApplication.java : UserDao에 대한 MapperScan 추가