### PR TITLE
오늘의 챌린지 생성 및 조회 기능 추가

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
@@ -1,0 +1,36 @@
+package com.him.fpjt.him_backend.exercise.controller;
+
+import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
+import com.him.fpjt.him_backend.exercise.service.TodayChallengeService;
+import java.time.LocalDate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/today-challenge")
+public class TodayChallengeController {
+    private TodayChallengeService todayChallengeService;
+
+    public TodayChallengeController(TodayChallengeService todayChallengeService) {
+        this.todayChallengeService = todayChallengeService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Object> createTodayChallenge(
+            @RequestParam("challengeId") long challengeId) {
+        TodayChallenge todayChallenge = new TodayChallenge(0, challengeId, LocalDate.now());
+        try {
+            long todayChallengeId = todayChallengeService.createTodayChallenge(todayChallenge);
+
+            return ResponseEntity.status(HttpStatus.CREATED).body(todayChallengeId);
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
@@ -3,8 +3,11 @@ package com.him.fpjt.him_backend.exercise.controller;
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import com.him.fpjt.him_backend.exercise.service.TodayChallengeService;
 import java.time.LocalDate;
+import java.util.NoSuchElementException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,6 +34,15 @@ public class TodayChallengeController {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
         } catch (RuntimeException e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
+    }
+    @GetMapping("{todayChallengeId}")
+    public ResponseEntity<Object> getTodayChallenge(@PathVariable("todayChallengeId") long id) {
+        try {
+            TodayChallenge todayChallenge = todayChallengeService.getTodayChallengeById(id);
+            return ResponseEntity.ok().body(todayChallenge);
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).body(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
@@ -1,6 +1,7 @@
 package com.him.fpjt.him_backend.exercise.controller;
 
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
+import com.him.fpjt.him_backend.exercise.dto.TodayChallengeDto;
 import com.him.fpjt.him_backend.exercise.service.TodayChallengeService;
 import java.time.LocalDate;
 import java.util.NoSuchElementException;
@@ -9,8 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,12 +25,13 @@ public class TodayChallengeController {
 
     @PostMapping
     public ResponseEntity<Object> createTodayChallenge(
-            @RequestParam("challengeId") long challengeId) {
-        TodayChallenge todayChallenge = new TodayChallenge(0, challengeId, LocalDate.now());
+            @RequestBody TodayChallengeDto todayChallengeDto) {
+        TodayChallenge todayChallenge = new TodayChallenge(todayChallengeDto.getCnt(), todayChallengeDto.getChallengeId(), todayChallengeDto.getDate());
         try {
             long todayChallengeId = todayChallengeService.createTodayChallenge(todayChallenge);
-
             return ResponseEntity.status(HttpStatus.CREATED).body(todayChallengeId);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
         } catch (IllegalStateException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
         } catch (RuntimeException e) {

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
@@ -10,4 +10,5 @@ public interface ChallengeDao {
     public Challenge selectChallenge(long id);
     public int deleteChallenge(long id);
     public int deleteTodayChallengeByChallengeId(long id);
+    public boolean existsChallengeById(long id);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
@@ -1,10 +1,12 @@
 package com.him.fpjt.him_backend.exercise.dao;
 
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
+import java.time.LocalDate;
 import java.util.Map;
 
 public interface TodayChallengeDao {
     public long insertTodayChallenge(TodayChallenge todayChallenge);
-    public boolean existsTodayChallengeByChallengeIdAndDate(Map<String, Object> map);
+    public boolean existsTodayChallengeByChallengeIdAndDate(long challengeId, LocalDate date);
     public TodayChallenge selectTodayChallengeById(long id);
+    public long updateTodayChallenge(TodayChallenge todayChallenge);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
@@ -2,7 +2,6 @@ package com.him.fpjt.him_backend.exercise.dao;
 
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import java.time.LocalDate;
-import java.util.Map;
 
 public interface TodayChallengeDao {
     public long insertTodayChallenge(TodayChallenge todayChallenge);

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
@@ -5,4 +5,5 @@ import java.util.Map;
 
 public interface TodayChallengeDao {
     public long insertTodayChallenge(TodayChallenge todayChallenge);
+    public boolean existsTodayChallengeByChallengeIdAndDate(Map<String, Object> map);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
@@ -6,4 +6,5 @@ import java.util.Map;
 public interface TodayChallengeDao {
     public long insertTodayChallenge(TodayChallenge todayChallenge);
     public boolean existsTodayChallengeByChallengeIdAndDate(Map<String, Object> map);
+    public TodayChallenge selectTodayChallengeById(long id);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
@@ -1,0 +1,8 @@
+package com.him.fpjt.him_backend.exercise.dao;
+
+import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
+import java.util.Map;
+
+public interface TodayChallengeDao {
+    public long insertTodayChallenge(TodayChallenge todayChallenge);
+}

--- a/src/main/java/com/him/fpjt/him_backend/exercise/domain/TodayChallenge.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/domain/TodayChallenge.java
@@ -1,5 +1,6 @@
 package com.him.fpjt.him_backend.exercise.domain;
 
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -11,5 +12,15 @@ public class TodayChallenge {
     private long id;
     private long cnt;
     private long challengeId;
-    private long userId;
+    private LocalDate date;
+
+    public TodayChallenge(long cnt, long challengeId, LocalDate date) {
+        this.cnt = cnt;
+        this.challengeId = challengeId;
+        this.date = date;
+    }
+
+    public void setCnt(long cnt) {
+        this.cnt = cnt;
+    }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dto/TodayChallengeDto.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dto/TodayChallengeDto.java
@@ -1,0 +1,19 @@
+package com.him.fpjt.him_backend.exercise.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@AllArgsConstructor
+@NoArgsConstructor
+public class TodayChallengeDto {
+    private long cnt = 0;
+    private long challengeId;
+    private LocalDate date = LocalDate.now();
+}

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
@@ -9,4 +9,5 @@ public interface ChallengeService {
     public List<Challenge> getChallengeByStatusAndUserId(long userId, ChallengeStatus status);
     public Challenge getChallengeDetail(long id);
     public boolean removeChallenge(long id);
+    public boolean existsChallengeById(long id);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
@@ -43,4 +43,9 @@ public class ChallengeServiceImpl implements ChallengeService {
         log.info("delete todaychallenge by challengeId");
         return challengeDao.deleteChallenge(id) > 0 ? true : false;
     }
+
+    @Override
+    public boolean existsChallengeById(long id) {
+        return challengeDao.existsChallengeById(id);
+    }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeService.java
@@ -1,0 +1,7 @@
+package com.him.fpjt.him_backend.exercise.service;
+
+import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
+
+public interface TodayChallengeService {
+    public long createTodayChallenge(TodayChallenge todayChallenge);
+}

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeService.java
@@ -4,4 +4,5 @@ import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 
 public interface TodayChallengeService {
     public long createTodayChallenge(TodayChallenge todayChallenge);
+    public TodayChallenge getTodayChallengeById(long id);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
@@ -39,7 +39,6 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
     }
 
     private boolean isTodayChallengeExists(long challengeId, LocalDate date) {
-        System.out.println(todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(challengeId, date));
         return todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(challengeId, date);
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
@@ -4,6 +4,8 @@ import com.him.fpjt.him_backend.exercise.dao.TodayChallengeDao;
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import java.time.LocalDate;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +30,12 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
         }
         return todayChallengeId;
     }
+    @Override
+    public TodayChallenge getTodayChallengeById(long id) {
+        return Optional.ofNullable(todayChallengeDao.selectTodayChallengeById(id))
+                .orElseThrow(() -> new NoSuchElementException("해당 ID의 오늘의 챌린지가 존재하지 않습니다."));
+    }
+
     private boolean isTodayChallengeExists(long challengeId, LocalDate date) {
         Map<String, Object> params = Map.of(
                 "challengeId", challengeId,

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
@@ -3,7 +3,6 @@ package com.him.fpjt.him_backend.exercise.service;
 import com.him.fpjt.him_backend.exercise.dao.TodayChallengeDao;
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import java.time.LocalDate;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
@@ -40,10 +39,7 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
     }
 
     private boolean isTodayChallengeExists(long challengeId, LocalDate date) {
-        Map<String, Object> params = Map.of(
-                "challengeId", challengeId,
-                "date", date
-        );
-        return todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(params);
+        System.out.println(todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(challengeId, date));
+        return todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(challengeId, date);
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
@@ -1,0 +1,38 @@
+package com.him.fpjt.him_backend.exercise.service;
+
+import com.him.fpjt.him_backend.exercise.dao.TodayChallengeDao;
+import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
+import java.time.LocalDate;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TodayChallengeServiceImpl implements TodayChallengeService {
+    private TodayChallengeDao todayChallengeDao;
+    private ChallengeService challengeService;
+    public TodayChallengeServiceImpl(TodayChallengeDao todayChallengeDao,
+            ChallengeService challengeService) {
+        this.todayChallengeDao = todayChallengeDao;
+        this.challengeService = challengeService;
+    }
+    @Transactional
+    @Override
+    public long createTodayChallenge(TodayChallenge todayChallenge) {
+        if (isTodayChallengeExists(todayChallenge.getChallengeId(), todayChallenge.getDate())) {
+            throw new IllegalStateException("이미 동일한 챌린지가 존재합니다.");
+        }
+        long todayChallengeId = todayChallengeDao.insertTodayChallenge(todayChallenge);
+        if (todayChallengeId <= 0) {
+            throw new RuntimeException("챌린지 생성에 실패했습니다.");
+        }
+        return todayChallengeId;
+    }
+    private boolean isTodayChallengeExists(long challengeId, LocalDate date) {
+        Map<String, Object> params = Map.of(
+                "challengeId", challengeId,
+                "date", date
+        );
+        return todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(params);
+    }
+}

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
@@ -21,6 +21,9 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
     @Transactional
     @Override
     public long createTodayChallenge(TodayChallenge todayChallenge) {
+        if(!challengeService.existsChallengeById(todayChallenge.getChallengeId())) {
+            throw new IllegalArgumentException("존재하지 않는 챌린지 id 입니다.");
+        }
         if (isTodayChallengeExists(todayChallenge.getChallengeId(), todayChallenge.getDate())) {
             throw new IllegalStateException("이미 동일한 챌린지가 존재합니다.");
         }

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -23,7 +23,4 @@
   <delete id="deleteChallenge" parameterType="long">
     DELETE FROM challenge WHERE id = #{id}
   </delete>
-  <delete id="deleteTodayChallengeByChallengeId" parameterType="long">
-    DELETE FROM today_challenge WHERE challenge_id = #{id}
-  </delete>
 </mapper>

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -23,4 +23,9 @@
   <delete id="deleteChallenge" parameterType="long">
     DELETE FROM challenge WHERE id = #{id}
   </delete>
+  <select id="existsChallengeById" parameterType="long" resultType="boolean">
+    SELECT EXISTS (
+        SELECT 1 FROM challenge WHERE id = #{id}
+    )
+  </select>
 </mapper>

--- a/src/main/resources/mappers/TodayChallengeMapper.xml
+++ b/src/main/resources/mappers/TodayChallengeMapper.xml
@@ -6,4 +6,11 @@
     INSERT INTO today_challenge (cnt, challenge_id, date)
     VALUES (#{cnt}, #{challengeId}, #{date})
   </insert>
+  <select id="existsTodayChallengeByChallengeIdAndDate" parameterType="map" resultType="boolean">
+      SELECT EXISTS (
+          SELECT 1 FROM today_challenge
+          WHERE date = #{date}
+          AND challenge_id = #{challengeId}
+      )
+  </select>
 </mapper>

--- a/src/main/resources/mappers/TodayChallengeMapper.xml
+++ b/src/main/resources/mappers/TodayChallengeMapper.xml
@@ -16,4 +16,7 @@
   <select id="selectTodayChallengeById" parameterType="long" resultType="TodayChallenge">
     SELECT * FROM today_challenge WHERE id = #{id}
   </select>
+  <delete id="deleteTodayChallengeByChallengeId" parameterType="long">
+    DELETE FROM today_challenge WHERE challenge_id = #{id}
+  </delete>
 </mapper>

--- a/src/main/resources/mappers/TodayChallengeMapper.xml
+++ b/src/main/resources/mappers/TodayChallengeMapper.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.him.fpjt.him_backend.exercise.dao.TodayChallengeDao">
+  <insert id="insertTodayChallenge" parameterType="TodayChallenge" useGeneratedKeys="true" keyProperty="id">
+    INSERT INTO today_challenge (cnt, challenge_id, date)
+    VALUES (#{cnt}, #{challengeId}, #{date})
+  </insert>
+</mapper>

--- a/src/main/resources/mappers/TodayChallengeMapper.xml
+++ b/src/main/resources/mappers/TodayChallengeMapper.xml
@@ -13,4 +13,7 @@
           AND challenge_id = #{challengeId}
       )
   </select>
+  <select id="selectTodayChallengeById" parameterType="long" resultType="TodayChallenge">
+    SELECT * FROM today_challenge WHERE id = #{id}
+  </select>
 </mapper>

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
@@ -47,7 +47,7 @@ public class ChallegeServiceImplTest {
                 mockChallenge.getId(),
                 10L,
                 1,
-                1L
+                LocalDate.now()
         );
     }
 

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
@@ -1,0 +1,59 @@
+package com.him.fpjt.him_backend.exercise.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.him.fpjt.him_backend.exercise.dao.TodayChallengeDao;
+import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class TodayChallengeServiceImplTest {
+    @Mock
+    private TodayChallengeDao todayChallengeDao;
+    @InjectMocks
+    private TodayChallengeServiceImpl todayChallengeService;
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("오늘의 챌린지 생성 성공 시 todayChalllengeId를 반환한다.")
+    public void createTodayChallenge_success() {
+        TodayChallenge todayChallenge = new TodayChallenge(0, 1L, LocalDate.now());
+        when(todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(anyMap())).thenReturn(false);
+        when(todayChallengeDao.insertTodayChallenge(todayChallenge)).thenReturn(1L);
+
+        long resultId = todayChallengeService.createTodayChallenge(todayChallenge);
+
+        assertEquals(1L, resultId);
+        verify(todayChallengeDao).insertTodayChallenge(todayChallenge);
+    }
+    @Test
+    @DisplayName("이미 오늘의 챌린지가 있는 경우, 예외가 발생한다.")
+    void createTodayChallenge_duplicate() {
+        TodayChallenge todayChallenge = new TodayChallenge(0, 1L, LocalDate.now());
+        when(todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(anyMap())).thenReturn(true);
+
+        assertThrows(IllegalStateException.class, () -> todayChallengeService.createTodayChallenge(todayChallenge));
+    }
+
+    @Test
+    @DisplayName("오늘의 챌린지 생성 실패 시, 예외가 발생한다.")
+    void createTodayChallenge_fail() {
+        TodayChallenge todayChallenge = new TodayChallenge(0, 1L, LocalDate.now());
+        when(todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(anyMap())).thenReturn(false);
+        when(todayChallengeDao.insertTodayChallenge(todayChallenge)).thenReturn(0L);
+
+        assertThrows(RuntimeException.class, () -> todayChallengeService.createTodayChallenge(todayChallenge));
+    }
+}

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
@@ -3,7 +3,6 @@ package com.him.fpjt.him_backend.exercise.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,7 +35,7 @@ public class TodayChallengeServiceImplTest {
         TodayChallenge todayChallenge = new TodayChallenge(0, 1L, LocalDate.now());
 
         when(challengeService.existsChallengeById(1L)).thenReturn(true);
-        when(todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(anyMap())).thenReturn(false);
+        when(todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(1L, LocalDate.now())).thenReturn(false);
         when(todayChallengeDao.insertTodayChallenge(todayChallenge)).thenReturn(1L);
 
         long resultId = todayChallengeService.createTodayChallenge(todayChallenge);
@@ -61,7 +60,7 @@ public class TodayChallengeServiceImplTest {
     void createTodayChallenge_duplicate() {
         TodayChallenge todayChallenge = new TodayChallenge(0, 1L, LocalDate.now());
         when(challengeService.existsChallengeById(1L)).thenReturn(true);
-        when(todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(anyMap())).thenReturn(true);
+        when(todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(1L, LocalDate.now())).thenReturn(true);
 
         assertThrows(IllegalStateException.class, () -> todayChallengeService.createTodayChallenge(todayChallenge));
     }
@@ -70,7 +69,7 @@ public class TodayChallengeServiceImplTest {
     @DisplayName("오늘의 챌린지 생성 실패 시, 예외가 발생한다.")
     void createTodayChallenge_fail() {
         TodayChallenge todayChallenge = new TodayChallenge(0, 1L, LocalDate.now());
-        when(todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(anyMap())).thenReturn(false);
+        when(todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(1L, LocalDate.now())).thenReturn(false);
         when(todayChallengeDao.insertTodayChallenge(todayChallenge)).thenReturn(0L);
 
         assertThrows(RuntimeException.class, () -> todayChallengeService.createTodayChallenge(todayChallenge));

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
@@ -21,6 +21,8 @@ import org.mockito.MockitoAnnotations;
 public class TodayChallengeServiceImplTest {
     @Mock
     private TodayChallengeDao todayChallengeDao;
+    @Mock
+    private ChallengeService challengeService;
     @InjectMocks
     private TodayChallengeServiceImpl todayChallengeService;
     @BeforeEach
@@ -32,6 +34,8 @@ public class TodayChallengeServiceImplTest {
     @DisplayName("오늘의 챌린지 생성 성공 시 todayChalllengeId를 반환한다.")
     public void createTodayChallenge_success() {
         TodayChallenge todayChallenge = new TodayChallenge(0, 1L, LocalDate.now());
+
+        when(challengeService.existsChallengeById(1L)).thenReturn(true);
         when(todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(anyMap())).thenReturn(false);
         when(todayChallengeDao.insertTodayChallenge(todayChallenge)).thenReturn(1L);
 
@@ -41,9 +45,22 @@ public class TodayChallengeServiceImplTest {
         verify(todayChallengeDao).insertTodayChallenge(todayChallenge);
     }
     @Test
+    @DisplayName("존재하지 않는 챌린지 id의 경우, 예외가 발생합니다.")
+    public void createTodayChallenge_notExistChallengeId() {
+        TodayChallenge todayChallenge = new TodayChallenge(0, 1L, LocalDate.now());
+        when(challengeService.existsChallengeById(1L)).thenReturn(false);
+
+        // when & then: 예외 검증
+        assertThrows(IllegalArgumentException.class,
+                () -> todayChallengeService.createTodayChallenge(todayChallenge),
+                "존재하지 않는 챌린지 id 입니다."
+        );
+    }
+    @Test
     @DisplayName("이미 오늘의 챌린지가 있는 경우, 예외가 발생한다.")
     void createTodayChallenge_duplicate() {
         TodayChallenge todayChallenge = new TodayChallenge(0, 1L, LocalDate.now());
+        when(challengeService.existsChallengeById(1L)).thenReturn(true);
         when(todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(anyMap())).thenReturn(true);
 
         assertThrows(IllegalStateException.class, () -> todayChallengeService.createTodayChallenge(todayChallenge));

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.him.fpjt.him_backend.exercise.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.verify;
@@ -9,6 +10,7 @@ import static org.mockito.Mockito.when;
 import com.him.fpjt.him_backend.exercise.dao.TodayChallengeDao;
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import java.time.LocalDate;
+import java.util.NoSuchElementException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,5 +57,26 @@ public class TodayChallengeServiceImplTest {
         when(todayChallengeDao.insertTodayChallenge(todayChallenge)).thenReturn(0L);
 
         assertThrows(RuntimeException.class, () -> todayChallengeService.createTodayChallenge(todayChallenge));
+    }
+
+    @Test
+    @DisplayName("오늘의 챌린지가 성공적으로 조회될 경우, 조회 결과를 반환한다.")
+    void getTodayChallengeById_success() {
+        TodayChallenge todayChallenge = new TodayChallenge(1L, 10L, 1L, LocalDate.now());
+        when(todayChallengeDao.selectTodayChallengeById(1L)).thenReturn(todayChallenge);
+
+        TodayChallenge result = todayChallengeService.getTodayChallengeById(1L);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        verify(todayChallengeDao).selectTodayChallengeById(1L);
+    }
+
+    @Test
+    @DisplayName("오늘의 챌린지가 존재하지 않는 경우, 예외가 발생한다.")
+    void getTodayChallengeById_NotFoundError() {
+        when(todayChallengeDao.selectTodayChallengeById(1L)).thenReturn(null);
+
+        assertThrows(NoSuchElementException.class, () -> todayChallengeService.getTodayChallengeById(1L));
     }
 }


### PR DESCRIPTION
## 연관된 이슈

> resolve #11 

## 작업 내용

> 오늘의 챌린지 생성 및 오늘의 챌린지 조회에 대한 기능을 추가하였습니다.
> - 오늘의 챌린지 생성 : challengeId를 이용하여 오늘의 챌린지를 생성할 수 있습니다. 요청 시 challengeId, date, count 값을 전달받으며, date와 count가 없을 경우, 기본값으로 현재 날짜와 count는 0이 설정됩니다.
> - 오늘의 챌린지 조회 : `todayChallengeId`로 특정 날짜의 챌린지 정보를 조회합니다.
## 리뷰 요구사항 (선택)
> `createTodayChallenge` 메서드는 `challengeId`, `date`, `count`를 설정할 수 있으며, date와 count를 주지 않으면 기본값을 설정하는 방식으로 구현했습니다. 이 과정에서 기존 도메인을 그대로 사용하는 방법과 dto를 사용하는 방식을 고민하다가 유연한 데이터 관리를 위해 dto를 추가하여 사용하였습니다.