### PR TITLE
게임 기능

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/HimBackendApplication.java
+++ b/src/main/java/com/him/fpjt/him_backend/HimBackendApplication.java
@@ -6,7 +6,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-@MapperScan(basePackages = "com.him.fpjt.him_backend.exercise.dao")
 @MapperScans({
 		@MapperScan("com.him.fpjt.him_backend.exercise.dao"),
 		@MapperScan("com.him.fpjt.him_backend.user.dao")

--- a/src/main/java/com/him/fpjt/him_backend/common/constants/ExpPoints.java
+++ b/src/main/java/com/him/fpjt/him_backend/common/constants/ExpPoints.java
@@ -1,0 +1,13 @@
+package com.him.fpjt.him_backend.common.constants;
+
+public class ExpPoints {
+    public static final int DAILY_ACHIVEMENT_EXP = 5;
+    public static final int SEVEN_DAY_STREAK_EXP = 10;
+    public static final int THIRTY_DAY_STREAK_EXP = 100;
+    public static final int SEVEN_DAY = 7;
+    public static final int THIRTY_DAY = 30;
+
+    public static final int GAME_EASY_MODE = 5;
+    public static final int GAME_MEDIUM_MODE = 10;
+    public static final int GAME_HARD_MODE = 20;
+}

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.NoSuchElementException;
+
 @RestController
 @RequestMapping("/api/game")
 public class GameController {
@@ -23,8 +25,12 @@ public class GameController {
         try {
             gameService.createGame(game);
             return ResponseEntity.ok("게임이 성공적으로 추가되었습니다.");
+        } catch (IllegalArgumentException e) {  // 유효하지 않은 입력 값일 때 발생
+            return new ResponseEntity<>("게임 생성 실패: 유효하지 않은 입력입니다. " + e.getMessage(), HttpStatus.BAD_REQUEST);
+        } catch (UnsupportedOperationException e) {  // 지원되지 않는 작업일 때 발생
+            return new ResponseEntity<>("게임 생성 실패: 지원되지 않는 작업입니다. " + e.getMessage(), HttpStatus.NOT_IMPLEMENTED);
         } catch (Exception e) {
-            return new ResponseEntity<>("게임 추가 실패: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>("알 수 없는 오류로 인해 게임 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -37,8 +43,12 @@ public class GameController {
             } else {
                 return ResponseEntity.ok("성취하지 않은 상태이므로 경험치가 반영되지 않았습니다.");
             }
+        } catch (NoSuchElementException e) {  // 게임을 찾을 수 없을 때 발생
+            return new ResponseEntity<>("경험치 반영 실패: 게임을 찾을 수 없습니다. " + e.getMessage(), HttpStatus.NOT_FOUND);
+        } catch (IllegalStateException e) {  // 상태가 적절하지 않을 때 발생
+            return new ResponseEntity<>("경험치 반영 실패: 상태가 적절하지 않습니다. " + e.getMessage(), HttpStatus.CONFLICT);
         } catch (Exception e) {
-            return new ResponseEntity<>("경험치 반영 실패: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>("알 수 없는 오류로 인해 경험치 반영에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
@@ -24,6 +24,12 @@ public class GameController {
         return isSave ?
                 new ResponseEntity<String>("Game added successfully", HttpStatus.OK) :
                 new ResponseEntity<String>("Failed to add game", HttpStatus.INTERNAL_SERVER_ERROR);
+        try {
+            gameService.createGame(game);
+            return ResponseEntity.ok("게임이 성공적으로 추가되었습니다.");
+        } catch (Exception e) {
+            return new ResponseEntity<>("게임 추가 실패: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     @PutMapping("/{gameId}")

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
@@ -1,7 +1,9 @@
 package com.him.fpjt.him_backend.exercise.controller;
 
 import com.him.fpjt.him_backend.exercise.domain.Game;
+import com.him.fpjt.him_backend.exercise.dto.GameDto;
 import com.him.fpjt.him_backend.exercise.service.GameService;
+import com.him.fpjt.him_backend.user.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +17,7 @@ public class GameController {
     private final GameService gameService;
 
     public GameController(GameService gameService) {
+    public GameController(GameService gameService, UserService userService) {
         this.gameService = gameService;
     }
 
@@ -38,6 +41,18 @@ public class GameController {
         return isSave ?
                 new ResponseEntity<String>("Game updated successfully", HttpStatus.OK) :
                 new ResponseEntity<String>("Failed to update game", HttpStatus.INTERNAL_SERVER_ERROR);
+    @PutMapping
+    public ResponseEntity<String> achieveGame(@RequestBody GameDto gameDto) {
+        try {
+            if (gameDto.isAchieved()) {
+                gameService.applyUserExp(gameDto.getGameId());
+                return ResponseEntity.ok("조건에 따른 경험치 반영이 완료되었습니다.");
+            } else {
+                return ResponseEntity.ok("성취하지 않은 상태이므로 경험치가 반영되지 않았습니다.");
+            }
+        } catch (Exception e) {
+            return new ResponseEntity<>("경험치 반영 실패: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
@@ -8,25 +8,18 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/game")
 public class GameController {
 
     private final GameService gameService;
 
-    public GameController(GameService gameService) {
     public GameController(GameService gameService, UserService userService) {
         this.gameService = gameService;
     }
 
     @PostMapping
     public ResponseEntity<String> createGame(@RequestBody Game game) {
-        boolean isSave = gameService.createGame(game);
-        return isSave ?
-                new ResponseEntity<String>("Game added successfully", HttpStatus.OK) :
-                new ResponseEntity<String>("Failed to add game", HttpStatus.INTERNAL_SERVER_ERROR);
         try {
             gameService.createGame(game);
             return ResponseEntity.ok("게임이 성공적으로 추가되었습니다.");
@@ -35,12 +28,6 @@ public class GameController {
         }
     }
 
-    @PutMapping("/{gameId}")
-    public ResponseEntity<String> modifyGame(@PathVariable("gameId") int id) {
-        boolean isSave = gameService.modifyGame(id);
-        return isSave ?
-                new ResponseEntity<String>("Game updated successfully", HttpStatus.OK) :
-                new ResponseEntity<String>("Failed to update game", HttpStatus.INTERNAL_SERVER_ERROR);
     @PutMapping
     public ResponseEntity<String> achieveGame(@RequestBody GameDto gameDto) {
         try {
@@ -54,5 +41,4 @@ public class GameController {
             return new ResponseEntity<>("경험치 반영 실패: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
-
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/GameDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/GameDao.java
@@ -3,6 +3,7 @@ package com.him.fpjt.him_backend.exercise.dao;
 import com.him.fpjt.him_backend.exercise.domain.Game;
 import java.time.LocalDate;
 import java.util.List;
+import com.him.fpjt.him_backend.exercise.dto.GameDto;
 
 import com.him.fpjt.him_backend.exercise.domain.Game;
 import java.time.LocalDate;

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/GameDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/GameDao.java
@@ -1,11 +1,8 @@
 package com.him.fpjt.him_backend.exercise.dao;
 
 import com.him.fpjt.him_backend.exercise.domain.Game;
-import java.time.LocalDate;
-import java.util.List;
 import com.him.fpjt.him_backend.exercise.dto.GameDto;
 
-import com.him.fpjt.him_backend.exercise.domain.Game;
 import java.time.LocalDate;
 
 public interface GameDao {

--- a/src/main/java/com/him/fpjt/him_backend/exercise/domain/Game.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/domain/Game.java
@@ -18,6 +18,7 @@ public class Game {
 
     public Game(ExerciseType type, DifficultyLevel difficultyLevel, boolean isAchieved,
             long userId) {
+    
     public Game(ExerciseType type, DifficultyLevel difficultyLevel, boolean isAchieved, long userId) {
         this.type = type;
         this.difficultyLevel = difficultyLevel;

--- a/src/main/java/com/him/fpjt/him_backend/exercise/domain/Game.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/domain/Game.java
@@ -15,9 +15,6 @@ public class Game {
     private DifficultyLevel difficultyLevel;
     private boolean isAchieved;
     private long userId;
-
-    public Game(ExerciseType type, DifficultyLevel difficultyLevel, boolean isAchieved,
-            long userId) {
     
     public Game(ExerciseType type, DifficultyLevel difficultyLevel, boolean isAchieved, long userId) {
         this.type = type;

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dto/GameDto.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dto/GameDto.java
@@ -1,0 +1,17 @@
+package com.him.fpjt.him_backend.exercise.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@AllArgsConstructor
+@NoArgsConstructor
+public class GameDto {
+    private long gameId;
+    private boolean isAchieved;
+}

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameService.java
@@ -9,5 +9,6 @@ public interface GameService {
     public boolean createGame(Game game);
 
     public boolean modifyGame(int id);
+    void createGame(Game game) throws Exception;
 
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameService.java
@@ -2,13 +2,8 @@ package com.him.fpjt.him_backend.exercise.service;
 
 import com.him.fpjt.him_backend.exercise.domain.Game;
 
-import java.util.List;
-
 public interface GameService {
 
-    public boolean createGame(Game game);
-
-    public boolean modifyGame(int id);
     void createGame(Game game) throws Exception;
 
     void applyUserExp(long gameId) throws Exception;

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameService.java
@@ -11,4 +11,5 @@ public interface GameService {
     public boolean modifyGame(int id);
     void createGame(Game game) throws Exception;
 
+    void applyUserExp(long gameId) throws Exception;
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
@@ -30,40 +30,53 @@ public class GameServiceImpl implements GameService {
 
     @Override
     @Transactional
-    public void applyUserExp(long gameId) throws Exception {
-        Game currentGame = gameDao.findGameById(gameId);
-        if (currentGame == null) {
-            throw new Exception("게임을 찾을 수 없습니다.");
-        }
-
+    public void applyUserExp(long gameId) {
+        Game currentGame = validateGameExists(gameId);
         long userId = currentGame.getUserId();
 
-        boolean hasSimilarAchievement = gameDao.existsAchievedGame(
+        if (!checkForSimilarAchievements(currentGame, userId)) {
+            long expPoints = calculateExpPoints(currentGame.getDifficultyLevel());
+            updateUserExperience(userId, expPoints);
+        }
+
+        updateGameAchievementStatus(gameId);
+    }
+
+    private Game validateGameExists(long gameId) {
+        Game game = gameDao.findGameById(gameId);
+        if (game == null) {
+            throw new NoSuchElementException("게임을 찾을 수 없습니다.");
+        }
+        return game;
+    }
+
+    private boolean checkForSimilarAchievements(Game currentGame, long userId) {
+        return gameDao.existsAchievedGame(
                 currentGame.getDate(),
                 currentGame.getType().name(),
                 currentGame.getDifficultyLevel().name(),
                 userId);
+    }
 
-        if (!hasSimilarAchievement) {
-            long expPoints = calculateExpPoints(currentGame.getDifficultyLevel());
-            int expUpdateResult = userDao.updateUserExp(userId, expPoints);
-
-            if (expUpdateResult == 0) {
-                throw new Exception("사용자 경험치 업데이트에 실패했습니다.");
-            }
+    private void updateUserExperience(long userId, long expPoints) {
+        int expUpdateResult = userDao.updateUserExp(userId, expPoints);
+        if (expUpdateResult == 0) {
+            throw new UnsupportedOperationException("사용자 경험치 업데이트에 실패했습니다.");
         }
+    }
 
+    private void updateGameAchievementStatus(long gameId) {
         int updateResult = gameDao.updateGameAchievement(gameId);
         if (updateResult == 0) {
-            throw new Exception("게임 성공 상태 업데이트에 실패했습니다.");
+            throw new IllegalStateException("게임 성공 상태 업데이트에 실패했습니다.");
         }
     }
 
     private long calculateExpPoints(DifficultyLevel difficultyLevel) {
         return switch (difficultyLevel) {
-            case EASY -> 5;
-            case MEDIUM -> 10;
-            case HARD -> 20;
+            case EASY -> ExpPoints.GAME_EASY_MODE;
+            case MEDIUM -> ExpPoints.GAME_MEDIUM_MODE;
+            case HARD -> ExpPoints.GAME_HARD_MODE;
         };
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
@@ -1,7 +1,10 @@
 package com.him.fpjt.him_backend.exercise.service;
 
 import com.him.fpjt.him_backend.exercise.dao.GameDao;
+import com.him.fpjt.him_backend.exercise.domain.DifficultyLevel;
 import com.him.fpjt.him_backend.exercise.domain.Game;
+import com.him.fpjt.him_backend.exercise.dto.GameDto;
+import com.him.fpjt.him_backend.user.dao.UserDao;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,9 +14,12 @@ import java.util.List;
 public class GameServiceImpl implements GameService {
 
     private final GameDao gameDao;
+    private final UserDao userDao;
 
     public GameServiceImpl(GameDao gameDao) {
+    public GameServiceImpl(GameDao gameDao, UserDao userDao) {
         this.gameDao = gameDao;
+        this.userDao = userDao;
     }
 
     @Override
@@ -31,6 +37,41 @@ public class GameServiceImpl implements GameService {
     @Transactional
     public boolean modifyGame(int id) {
         return gameDao.updateGame(id) != 0;
+    public void applyUserExp(long gameId) throws Exception {
+        Game currentGame = gameDao.findGameById(gameId);
+        if (currentGame == null) {
+            throw new Exception("게임을 찾을 수 없습니다.");
+        }
+
+        long userId = currentGame.getUserId();
+
+        boolean hasSimilarAchievement = gameDao.existsAchievedGame(
+                currentGame.getDate(),
+                currentGame.getType().name(),
+                currentGame.getDifficultyLevel().name(),
+                userId);
+
+        if (!hasSimilarAchievement) {
+            long expPoints = calculateExpPoints(currentGame.getDifficultyLevel());
+            int expUpdateResult = userDao.updateUserExp(userId, expPoints);
+
+            if (expUpdateResult == 0) {
+                throw new Exception("사용자 경험치 업데이트에 실패했습니다.");
+            }
+        }
+
+        int updateResult = gameDao.updateGameAchievement(gameId);
+        if (updateResult == 0) {
+            throw new Exception("게임 성공 상태 업데이트에 실패했습니다.");
+        }
     }
 
+}    private long calculateExpPoints(DifficultyLevel difficultyLevel) {
+    private long calculateExpPoints(DifficultyLevel difficultyLevel) {
+        return switch (difficultyLevel) {
+            case EASY -> 5;
+            case MEDIUM -> 10;
+            case HARD -> 20;
+        };
+    }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
@@ -20,6 +20,11 @@ public class GameServiceImpl implements GameService {
     @Transactional
     public boolean createGame(Game game) {
         return gameDao.insertGame(game) != 0;
+    public void createGame(Game game) throws Exception {
+        int result = gameDao.insertGame(game);
+        if (result == 0) {
+            throw new Exception("게임 생성에 실패했습니다.");
+        }
     }
 
     @Override

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
@@ -1,12 +1,14 @@
 package com.him.fpjt.him_backend.exercise.service;
 
+import com.him.fpjt.him_backend.common.constants.ExpPoints;
 import com.him.fpjt.him_backend.exercise.dao.GameDao;
 import com.him.fpjt.him_backend.exercise.domain.DifficultyLevel;
 import com.him.fpjt.him_backend.exercise.domain.Game;
-import com.him.fpjt.him_backend.exercise.dto.GameDto;
 import com.him.fpjt.him_backend.user.dao.UserDao;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
 
 @Service
 public class GameServiceImpl implements GameService {
@@ -21,10 +23,10 @@ public class GameServiceImpl implements GameService {
 
     @Override
     @Transactional
-    public void createGame(Game game) throws Exception {
+    public void createGame(Game game) {
         int result = gameDao.insertGame(game);
         if (result == 0) {
-            throw new Exception("게임 생성에 실패했습니다.");
+            throw new IllegalStateException("게임 생성에 실패했습니다.");
         }
     }
 

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
@@ -8,15 +8,12 @@ import com.him.fpjt.him_backend.user.dao.UserDao;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 public class GameServiceImpl implements GameService {
 
     private final GameDao gameDao;
     private final UserDao userDao;
 
-    public GameServiceImpl(GameDao gameDao) {
     public GameServiceImpl(GameDao gameDao, UserDao userDao) {
         this.gameDao = gameDao;
         this.userDao = userDao;
@@ -24,8 +21,6 @@ public class GameServiceImpl implements GameService {
 
     @Override
     @Transactional
-    public boolean createGame(Game game) {
-        return gameDao.insertGame(game) != 0;
     public void createGame(Game game) throws Exception {
         int result = gameDao.insertGame(game);
         if (result == 0) {
@@ -35,8 +30,6 @@ public class GameServiceImpl implements GameService {
 
     @Override
     @Transactional
-    public boolean modifyGame(int id) {
-        return gameDao.updateGame(id) != 0;
     public void applyUserExp(long gameId) throws Exception {
         Game currentGame = gameDao.findGameById(gameId);
         if (currentGame == null) {
@@ -66,7 +59,6 @@ public class GameServiceImpl implements GameService {
         }
     }
 
-}    private long calculateExpPoints(DifficultyLevel difficultyLevel) {
     private long calculateExpPoints(DifficultyLevel difficultyLevel) {
         return switch (difficultyLevel) {
             case EASY -> 5;

--- a/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
@@ -1,9 +1,5 @@
 package com.him.fpjt.him_backend.user.dao;
 
-import com.him.fpjt.him_backend.user.domain.User;
-
-import java.util.List;
-
 public interface UserDao {
 
     int updateUserExp(long userId, long expPoints);

--- a/src/main/java/com/him/fpjt/him_backend/user/service/UserService.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/UserService.java
@@ -1,0 +1,6 @@
+package com.him.fpjt.him_backend.user.service;
+
+public interface UserService {
+
+    void updateUserExp(long userId, long expPoints) throws Exception;
+}

--- a/src/main/java/com/him/fpjt/him_backend/user/service/UserService.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/UserService.java
@@ -2,5 +2,5 @@ package com.him.fpjt.him_backend.user.service;
 
 public interface UserService {
 
-    void updateUserExp(long userId, long expPoints) throws Exception;
+    void modifyUserExp(long userId, long expPoints) throws Exception;
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
@@ -15,10 +15,10 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public void updateUserExp(long userId, long expPoints) throws Exception {
+    public void modifyUserExp(long userId, long expPoints) {
         int updateResult = userDao.updateUserExp(userId, expPoints);
         if (updateResult == 0) {
-            throw new Exception("사용자 경험치 업데이트에 실패했습니다.");
+            throw new UnsupportedOperationException("사용자 경험치 업데이트에 실패했습니다.");
         }
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
@@ -1,0 +1,24 @@
+package com.him.fpjt.him_backend.user.service;
+
+import com.him.fpjt.him_backend.user.dao.UserDao;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserServiceImpl implements UserService {
+
+    private final UserDao userDao;
+
+    public UserServiceImpl(UserDao userDao) {
+        this.userDao = userDao;
+    }
+
+    @Override
+    @Transactional
+    public void updateUserExp(long userId, long expPoints) throws Exception {
+        int updateResult = userDao.updateUserExp(userId, expPoints);
+        if (updateResult == 0) {
+            throw new Exception("사용자 경험치 업데이트에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/resources/mappers/GameMapper.xml
+++ b/src/main/resources/mappers/GameMapper.xml
@@ -10,7 +10,6 @@
         VALUES (#{date}, #{type}, #{difficultyLevel}, false, #{userId})
     </insert>
 
-    <!-- 특정 게임 ID로 게임 정보 조회 -->
     <!-- 특정 게임 ID로 게임 정보 조회 (userId 포함) -->
     <select id="findGameById" parameterType="long" resultType="Game">
         SELECT * FROM game WHERE id = #{gameId}
@@ -28,7 +27,6 @@
         )
     </select>
 
-    <!-- 특정 게임 ID로 성공 여부를 수정하는 SQL 구문 -->
     <!-- 특정 게임 ID로 성공 여부를 true로 수정하는 SQL 구문 -->
     <update id="updateGameAchievement" parameterType="long">
         UPDATE game

--- a/src/main/resources/mappers/GameMapper.xml
+++ b/src/main/resources/mappers/GameMapper.xml
@@ -11,6 +11,7 @@
     </insert>
 
     <!-- 특정 게임 ID로 게임 정보 조회 -->
+    <!-- 특정 게임 ID로 게임 정보 조회 (userId 포함) -->
     <select id="findGameById" parameterType="long" resultType="Game">
         SELECT * FROM game WHERE id = #{gameId}
     </select>
@@ -28,6 +29,7 @@
     </select>
 
     <!-- 특정 게임 ID로 성공 여부를 수정하는 SQL 구문 -->
+    <!-- 특정 게임 ID로 성공 여부를 true로 수정하는 SQL 구문 -->
     <update id="updateGameAchievement" parameterType="long">
         UPDATE game
         SET is_achieved = true

--- a/src/test/java/com/him/fpjt/him_backend/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/user/service/UserServiceImplTest.java
@@ -25,40 +25,40 @@ class UserServiceImplTest {
     }
 
     @Test
-    void updateUserExp_success() {
+    void modifyUserExp_success() {
         long userId = 1L;
         long expPoints = 20L;
 
         when(userDao.updateUserExp(userId, expPoints)).thenReturn(1);
 
-        assertDoesNotThrow(() -> userService.updateUserExp(userId, expPoints));
+        assertDoesNotThrow(() -> userService.modifyUserExp(userId, expPoints));
         verify(userDao, times(1)).updateUserExp(userId, expPoints);
     }
 
     @Test
-    void updateUserExp_failure() {
+    void modifyUserExp_failure() {
         long userId = 1L;
         long expPoints = 20L;
 
         when(userDao.updateUserExp(userId, expPoints)).thenReturn(0);
 
-        Exception exception = assertThrows(Exception.class, () -> userService.updateUserExp(userId, expPoints));
+        Exception exception = assertThrows(Exception.class, () -> userService.modifyUserExp(userId, expPoints));
         verify(userDao, times(1)).updateUserExp(userId, expPoints);
     }
 
     @Test
-    void updateUserExp_noEffectOnInvalidUserId() {
+    void modifyUserExp_noEffectOnInvalidUserId() {
         long invalidUserId = -1L;
         long expPoints = 10L;
 
         when(userDao.updateUserExp(invalidUserId, expPoints)).thenReturn(0);
 
-        Exception exception = assertThrows(Exception.class, () -> userService.updateUserExp(invalidUserId, expPoints));
+        Exception exception = assertThrows(Exception.class, () -> userService.modifyUserExp(invalidUserId, expPoints));
         verify(userDao, times(1)).updateUserExp(invalidUserId, expPoints);
     }
 
     @Test
-    void updateUserExp_zeroExperiencePoints() {
+    void modifyUserExp_zeroExperiencePoints() {
         long userId = 1L;
         long expPoints = 0;
 
@@ -66,7 +66,7 @@ class UserServiceImplTest {
         when(userDao.updateUserExp(userId, expPoints)).thenReturn(1);
 
         // When & Then
-        assertDoesNotThrow(() -> userService.updateUserExp(userId, expPoints));
+        assertDoesNotThrow(() -> userService.modifyUserExp(userId, expPoints));
         verify(userDao, times(1)).updateUserExp(userId, expPoints);
     }
 }

--- a/src/test/java/com/him/fpjt/him_backend/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/user/service/UserServiceImplTest.java
@@ -1,0 +1,72 @@
+package com.him.fpjt.him_backend.user.service;
+
+import com.him.fpjt.him_backend.user.dao.UserDao;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+class UserServiceImplTest {
+
+    @Mock
+    private UserDao userDao;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void updateUserExp_success() {
+        long userId = 1L;
+        long expPoints = 20L;
+
+        when(userDao.updateUserExp(userId, expPoints)).thenReturn(1);
+
+        assertDoesNotThrow(() -> userService.updateUserExp(userId, expPoints));
+        verify(userDao, times(1)).updateUserExp(userId, expPoints);
+    }
+
+    @Test
+    void updateUserExp_failure() {
+        long userId = 1L;
+        long expPoints = 20L;
+
+        when(userDao.updateUserExp(userId, expPoints)).thenReturn(0);
+
+        Exception exception = assertThrows(Exception.class, () -> userService.updateUserExp(userId, expPoints));
+        verify(userDao, times(1)).updateUserExp(userId, expPoints);
+    }
+
+    @Test
+    void updateUserExp_noEffectOnInvalidUserId() {
+        long invalidUserId = -1L;
+        long expPoints = 10L;
+
+        when(userDao.updateUserExp(invalidUserId, expPoints)).thenReturn(0);
+
+        Exception exception = assertThrows(Exception.class, () -> userService.updateUserExp(invalidUserId, expPoints));
+        verify(userDao, times(1)).updateUserExp(invalidUserId, expPoints);
+    }
+
+    @Test
+    void updateUserExp_zeroExperiencePoints() {
+        long userId = 1L;
+        long expPoints = 0;
+
+        // Given: updateUserExp가 성공적으로 업데이트 된다고 가정
+        when(userDao.updateUserExp(userId, expPoints)).thenReturn(1);
+
+        // When & Then
+        assertDoesNotThrow(() -> userService.updateUserExp(userId, expPoints));
+        verify(userDao, times(1)).updateUserExp(userId, expPoints);
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

> #12 

## 작업 내용

> 기존에 프론트 단에서 성공한 게임만 받는 것에서 게임 아이디와 성공 여부를 받아 백 단에서 처리하는 코드로 변경하였습니다.

> 게임 아이디와 성공 여부는 게임 dto를 따로 받아 @PutMapping과 @RequestBody을 활용하여 RESTful API을 반영하였습니다.
> 서비스 단, 메퍼 단의 로직은 동일합니다.

> 불필요한 코드를 삭제하였습니다.

> 게임 서비스 구현체와 사용자 서비스 구현체에 대한 테스트 코드를 작성하였습니다.

## 리뷰어가 특별히 봐주었으면 하는 부분
> develop 브랜치에 최근 반영된 내용이 덜 반영되어서 불필요한 코드들이 많았고, 반영이 되다가 말아버린 코드들도 많아서 코드를 리뷰하시는데 어려움이 많을 것이라고 판단합니다.
> 최대한 commit 단위를 주제별로 나누려고 노력했습니다.
> commit 단위를 나누는 방법과 git을 활용하는 방법을 익혔기 때문에 다음에는 수정된 내용을 더 가시성있게 확인해보실 수 있을 겁니다.

> 추가로, 코드와 관련되어 게임 아이디와 성공 여부를 받는 것으로 로직이 변경된 사항을 주의깊게 봐주세요.
