### PR TITLE
챌린지 운동 결과 업데이트 및 경험치 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ dependencies {
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
 	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/him/fpjt/him_backend/HimBackendApplication.java
+++ b/src/main/java/com/him/fpjt/him_backend/HimBackendApplication.java
@@ -4,9 +4,10 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.mybatis.spring.annotation.MapperScans;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@MapperScan(basePackages = "com.him.fpjt.him_backend.exercise.dao")
+@EnableScheduling
 @MapperScans({
 		@MapperScan("com.him.fpjt.him_backend.exercise.dao"),
 		@MapperScan("com.him.fpjt.him_backend.user.dao")

--- a/src/main/java/com/him/fpjt/him_backend/common/constants/ExpPoints.java
+++ b/src/main/java/com/him/fpjt/him_backend/common/constants/ExpPoints.java
@@ -1,0 +1,5 @@
+package com.him.fpjt.him_backend.common.constants;
+
+public class ExpPoints {
+    public static final int DAILY_PENALTY_EXP = -3;
+}

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,6 +46,16 @@ public class TodayChallengeController {
             return ResponseEntity.ok().body(todayChallenge);
         } catch (NoSuchElementException e) {
             return ResponseEntity.status(HttpStatus.NO_CONTENT).body(e.getMessage());
+        }
+    }
+    @PutMapping
+    public ResponseEntity<Object> modifyTodayChallenge(
+                                                        @RequestBody TodayChallengeDto todayChallengeDto) {
+        try {
+            todayChallengeService.modifyTodayChallenge(todayChallengeDto);
+            return ResponseEntity.ok("오늘의 챌린지가 성공적으로 수정되었습니다.");
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 ID의 오늘의 챌린지를 찾을 수 없습니다.");
         }
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
@@ -12,5 +12,6 @@ public interface ChallengeDao {
     public int deleteChallenge(long id);
     public int deleteTodayChallengeByChallengeId(long id);
     public boolean existsChallengeById(long id);
+    public int updateChallengeAchieveCnt(long id);
     public List<Challenge> findChallengesWithoutTodayRecord(LocalDate yesterday);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
@@ -1,6 +1,7 @@
 package com.him.fpjt.him_backend.exercise.dao;
 
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -11,4 +12,5 @@ public interface ChallengeDao {
     public int deleteChallenge(long id);
     public int deleteTodayChallengeByChallengeId(long id);
     public boolean existsChallengeById(long id);
+    public List<Challenge> findChallengesWithoutTodayRecord(LocalDate yesterday);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
@@ -9,6 +9,6 @@ public interface TodayChallengeDao {
     public boolean existsTodayChallengeByChallengeIdAndDate(long challengeId, LocalDate date);
     public TodayChallenge selectTodayChallengeById(long id);
     public long updateTodayChallenge(TodayChallenge todayChallenge);
-    public boolean checkAchievementStreak(long challengeId, LocalDate date, int days);
+    public boolean checkAchievementBonus(long challengeId, LocalDate date, int days);
     public List<TodayChallenge> findUnachievedChallenges(LocalDate yesterday);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
@@ -2,10 +2,12 @@ package com.him.fpjt.him_backend.exercise.dao;
 
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import java.time.LocalDate;
+import java.util.List;
 
 public interface TodayChallengeDao {
     public long insertTodayChallenge(TodayChallenge todayChallenge);
     public boolean existsTodayChallengeByChallengeIdAndDate(long challengeId, LocalDate date);
     public TodayChallenge selectTodayChallengeById(long id);
     public long updateTodayChallenge(TodayChallenge todayChallenge);
+    public List<TodayChallenge> findUnachievedChallenges(LocalDate yesterday);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
@@ -9,5 +9,6 @@ public interface TodayChallengeDao {
     public boolean existsTodayChallengeByChallengeIdAndDate(long challengeId, LocalDate date);
     public TodayChallenge selectTodayChallengeById(long id);
     public long updateTodayChallenge(TodayChallenge todayChallenge);
+    public boolean checkAchievementStreak(long challengeId, LocalDate date, int days);
     public List<TodayChallenge> findUnachievedChallenges(LocalDate yesterday);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dto/TodayChallengeDto.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dto/TodayChallengeDto.java
@@ -13,7 +13,14 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TodayChallengeDto {
+    private long id;
     private long cnt = 0;
     private long challengeId;
     private LocalDate date = LocalDate.now();
+
+    public TodayChallengeDto(long cnt, long challengeId, LocalDate date) {
+        this.cnt = cnt;
+        this.challengeId = challengeId;
+        this.date = date;
+    }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
@@ -11,5 +11,6 @@ public interface ChallengeService {
     public Challenge getChallengeDetail(long id);
     public boolean removeChallenge(long id);
     public boolean existsChallengeById(long id);
+    public boolean modifyChallengeAchieveCnt(long id);
     public List<Challenge> findChallengesWithoutTodayRecord(LocalDate yesterday);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
@@ -2,6 +2,7 @@ package com.him.fpjt.him_backend.exercise.service;
 
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
 import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ChallengeService {
@@ -10,4 +11,5 @@ public interface ChallengeService {
     public Challenge getChallengeDetail(long id);
     public boolean removeChallenge(long id);
     public boolean existsChallengeById(long id);
+    public List<Challenge> findChallengesWithoutTodayRecord(LocalDate yesterday);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
@@ -51,6 +51,11 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     @Override
+    public boolean modifyChallengeAchieveCnt(long id) {
+        return challengeDao.updateChallengeAchieveCnt(id) > 0;
+    }
+
+    @Override
     public List<Challenge> findChallengesWithoutTodayRecord(LocalDate yesterday) {
         return challengeDao.findChallengesWithoutTodayRecord(yesterday);
     }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
@@ -3,6 +3,7 @@ package com.him.fpjt.him_backend.exercise.service;
 import com.him.fpjt.him_backend.exercise.dao.ChallengeDao;
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
 import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,5 +48,10 @@ public class ChallengeServiceImpl implements ChallengeService {
     @Override
     public boolean existsChallengeById(long id) {
         return challengeDao.existsChallengeById(id);
+    }
+
+    @Override
+    public List<Challenge> findChallengesWithoutTodayRecord(LocalDate yesterday) {
+        return challengeDao.findChallengesWithoutTodayRecord(yesterday);
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeService.java
@@ -1,9 +1,11 @@
 package com.him.fpjt.him_backend.exercise.service;
 
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
+import com.him.fpjt.him_backend.exercise.dto.TodayChallengeDto;
 
 public interface TodayChallengeService {
     public long createTodayChallenge(TodayChallenge todayChallenge);
     public TodayChallenge getTodayChallengeById(long id);
+    public boolean modifyTodayChallenge(TodayChallengeDto todayChallengeDto);
     public void modifyUnachievementTodayChallenge();
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeService.java
@@ -5,4 +5,5 @@ import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 public interface TodayChallengeService {
     public long createTodayChallenge(TodayChallenge todayChallenge);
     public TodayChallenge getTodayChallengeById(long id);
+    public void modifyUnachievementTodayChallenge();
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
@@ -67,9 +67,9 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
     }
 
     private void addAchievementExp(TodayChallenge todayChallenge, Challenge challenge) {
-        int streakExp = calculateAchievementStreakExp(todayChallenge.getChallengeId(), todayChallenge.getDate());
-        if (streakExp > 0) {
-            userService.modifyUserExp(challenge.getUserId(), streakExp);
+        int bonusExp = calculateAchievementBonusExp(todayChallenge.getChallengeId(), todayChallenge.getDate());
+        if (bonusExp > 0) {
+            userService.modifyUserExp(challenge.getUserId(), bonusExp);
         }
         userService.modifyUserExp(challenge.getUserId(), ExpPoints.DAILY_ACHIVEMENT_EXP);
     }
@@ -83,9 +83,9 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
         return todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(challengeId, date);
     }
 
-    private int calculateAchievementStreakExp(long challengeId, LocalDate currentDate) {
-        boolean isSevenDayStreak = todayChallengeDao.checkAchievementStreak(challengeId, currentDate, ExpPoints.SEVEN_DAY);
-        boolean isThirtyDayStreak = todayChallengeDao.checkAchievementStreak(challengeId, currentDate, ExpPoints.THIRTY_DAY);
+    private int calculateAchievementBonusExp(long challengeId, LocalDate currentDate) {
+        boolean isSevenDayStreak = todayChallengeDao.checkAchievementBonus(challengeId, currentDate, ExpPoints.SEVEN_DAY);
+        boolean isThirtyDayStreak = todayChallengeDao.checkAchievementBonus(challengeId, currentDate, ExpPoints.THIRTY_DAY);
 
         if (isThirtyDayStreak) return ExpPoints.THIRTY_DAY_STREAK_EXP;
         if (isSevenDayStreak) return ExpPoints.SEVEN_DAY_STREAK_EXP;

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
@@ -70,9 +70,8 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
         int streakExp = calculateAchievementStreakExp(todayChallenge.getChallengeId(), todayChallenge.getDate());
         if (streakExp > 0) {
             userService.modifyUserExp(challenge.getUserId(), streakExp);
-        } else {
-            userService.modifyUserExp(challenge.getUserId(), ExpPoints.DAILY_ACHIVEMENT_EXP);
         }
+        userService.modifyUserExp(challenge.getUserId(), ExpPoints.DAILY_ACHIVEMENT_EXP);
     }
 
     private boolean isGoalAchieved(TodayChallenge todayChallenge) {

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
@@ -52,7 +52,6 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
     @Transactional
     @Override
     public boolean modifyTodayChallenge(TodayChallengeDto newTodayChallengeDto) {
-        log.info("오늘의 챌린지 변경 service");
         TodayChallenge todayChallenge = getTodayChallengeById(newTodayChallengeDto.getId());
         todayChallenge.setCnt(newTodayChallengeDto.getCnt());
         boolean isUpdated = todayChallengeDao.updateTodayChallenge(todayChallenge) > 0;

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
@@ -1,10 +1,15 @@
 package com.him.fpjt.him_backend.exercise.service;
 
+import com.him.fpjt.him_backend.common.constants.ExpPoints;
 import com.him.fpjt.him_backend.exercise.dao.TodayChallengeDao;
+import com.him.fpjt.him_backend.exercise.domain.Challenge;
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
+import com.him.fpjt.him_backend.user.service.UserService;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,11 +17,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class TodayChallengeServiceImpl implements TodayChallengeService {
     private TodayChallengeDao todayChallengeDao;
     private ChallengeService challengeService;
+    private UserService userService;
+
     public TodayChallengeServiceImpl(TodayChallengeDao todayChallengeDao,
-            ChallengeService challengeService) {
+            ChallengeService challengeService, UserService userService) {
         this.todayChallengeDao = todayChallengeDao;
         this.challengeService = challengeService;
+        this.userService = userService;
     }
+
     @Transactional
     @Override
     public long createTodayChallenge(TodayChallenge todayChallenge) {
@@ -40,5 +49,22 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
 
     private boolean isTodayChallengeExists(long challengeId, LocalDate date) {
         return todayChallengeDao.existsTodayChallengeByChallengeIdAndDate(challengeId, date);
+    }
+    @Scheduled(cron = "0 0 1 * * ?")
+    @Transactional
+    @Override
+    public void modifyUnachievementTodayChallenge() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        List<TodayChallenge> unachievedTodayChallenges = todayChallengeDao.findUnachievedChallenges(yesterday);
+
+        for (TodayChallenge unachievedTodayChallenge : unachievedTodayChallenges) {
+            userService.modifyUserExp(challengeService.getChallengeDetail(unachievedTodayChallenge.getChallengeId()).getUserId(), ExpPoints.DAILY_PENALTY_EXP);
+        }
+
+        List<Challenge> missingChallenges = challengeService.findChallengesWithoutTodayRecord(yesterday);
+
+        for (Challenge missingChallenge : missingChallenges) {
+            userService.modifyUserExp(missingChallenge.getUserId(), ExpPoints.DAILY_PENALTY_EXP);
+        }
     }
 }

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -28,6 +28,9 @@
         SELECT 1 FROM challenge WHERE id = #{id}
     )
   </select>
+  <update id="updateChallengeAchieveCnt" parameterType="long">
+    UPDATE challenge SET achieve_cnt = achieve_cnt + 1 WHERE id = #{id}
+  </update>
   <select id="findChallengesWithoutTodayRecord" parameterType="java.time.LocalDate" resultType="Challenge">
     SELECT *
     FROM challenge c

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -28,4 +28,15 @@
         SELECT 1 FROM challenge WHERE id = #{id}
     )
   </select>
+  <select id="findChallengesWithoutTodayRecord" parameterType="java.time.LocalDate" resultType="Challenge">
+    SELECT *
+    FROM challenge c
+    WHERE c.status = 'ONGOING'
+    AND NOT EXISTS(
+        SELECT 1
+        FROM today_challenge tc
+        WHERE tc.challenge_id = c.id
+          AND tc.date = #{yesterday}
+      )
+  </select>
 </mapper>

--- a/src/main/resources/mappers/TodayChallengeMapper.xml
+++ b/src/main/resources/mappers/TodayChallengeMapper.xml
@@ -19,6 +19,13 @@
   <delete id="deleteTodayChallengeByChallengeId" parameterType="long">
     DELETE FROM today_challenge WHERE challenge_id = #{id}
   </delete>
+  <select id="checkAchievementStreak" parameterType="map" resultType="boolean">
+    SELECT COUNT(*) = #{days}
+    FROM today_challenge
+    WHERE challenge_id = #{challengeId}
+      AND date >= DATE_SUB(#{date}, INTERVAL #{days} DAY)
+      AND cnt >= (SELECT goal_cnt FROM challenge WHERE id = #{challengeId})
+  </select>
   <select id="findUnachievedChallenges" parameterType="java.time.LocalDate" resultType="TodayChallenge">
     SELECT *
     FROM today_challenge tc

--- a/src/main/resources/mappers/TodayChallengeMapper.xml
+++ b/src/main/resources/mappers/TodayChallengeMapper.xml
@@ -16,6 +16,9 @@
   <select id="selectTodayChallengeById" parameterType="long" resultType="TodayChallenge">
     SELECT * FROM today_challenge WHERE id = #{id}
   </select>
+  <update id="updateTodayChallenge" parameterType="TodayChallenge">
+    UPDATE today_challenge SET cnt = #{cnt} WHERE id = #{id}
+  </update>
   <delete id="deleteTodayChallengeByChallengeId" parameterType="long">
     DELETE FROM today_challenge WHERE challenge_id = #{id}
   </delete>

--- a/src/main/resources/mappers/TodayChallengeMapper.xml
+++ b/src/main/resources/mappers/TodayChallengeMapper.xml
@@ -22,7 +22,7 @@
   <delete id="deleteTodayChallengeByChallengeId" parameterType="long">
     DELETE FROM today_challenge WHERE challenge_id = #{id}
   </delete>
-  <select id="checkAchievementStreak" parameterType="map" resultType="boolean">
+  <select id="checkAchievementBonus" parameterType="map" resultType="boolean">
     SELECT COUNT(*) = #{days}
     FROM today_challenge
     WHERE challenge_id = #{challengeId}

--- a/src/main/resources/mappers/TodayChallengeMapper.xml
+++ b/src/main/resources/mappers/TodayChallengeMapper.xml
@@ -19,4 +19,12 @@
   <delete id="deleteTodayChallengeByChallengeId" parameterType="long">
     DELETE FROM today_challenge WHERE challenge_id = #{id}
   </delete>
+  <select id="findUnachievedChallenges" parameterType="java.time.LocalDate" resultType="TodayChallenge">
+    SELECT *
+    FROM today_challenge tc
+           JOIN challenge c ON tc.challenge_id = c.id
+    WHERE tc.date = #{yesterday}
+      AND c.status = 'ONGOING'
+      AND tc.cnt &lt; c.goal_cnt
+  </select>
 </mapper>

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
@@ -140,8 +140,8 @@ public class TodayChallengeServiceImplTest {
 
         when(todayChallengeDao.updateTodayChallenge(any(TodayChallenge.class))).thenReturn(1L);
         when(challengeService.getChallengeDetail(todayChallengeDto.getChallengeId())).thenReturn(challenge);
-        when(todayChallengeDao.checkAchievementStreak(challenge.getId(), LocalDate.now(), ExpPoints.SEVEN_DAY)).thenReturn(true);
-        when(todayChallengeDao.checkAchievementStreak(challenge.getId(), LocalDate.now(), ExpPoints.THIRTY_DAY)).thenReturn(false);
+        when(todayChallengeDao.checkAchievementBonus(challenge.getId(), LocalDate.now(), ExpPoints.SEVEN_DAY)).thenReturn(true);
+        when(todayChallengeDao.checkAchievementBonus(challenge.getId(), LocalDate.now(), ExpPoints.THIRTY_DAY)).thenReturn(false);
 
         assertTrue(todayChallengeService.modifyTodayChallenge(todayChallengeDto));
 
@@ -160,8 +160,8 @@ public class TodayChallengeServiceImplTest {
 
         when(todayChallengeDao.updateTodayChallenge(any(TodayChallenge.class))).thenReturn(1L);
         when(challengeService.getChallengeDetail(todayChallengeDto.getChallengeId())).thenReturn(challenge);
-        when(todayChallengeDao.checkAchievementStreak(challenge.getId(), LocalDate.now(), ExpPoints.SEVEN_DAY)).thenReturn(false);
-        when(todayChallengeDao.checkAchievementStreak(challenge.getId(), LocalDate.now(), ExpPoints.THIRTY_DAY)).thenReturn(false);
+        when(todayChallengeDao.checkAchievementBonus(challenge.getId(), LocalDate.now(), ExpPoints.SEVEN_DAY)).thenReturn(false);
+        when(todayChallengeDao.checkAchievementBonus(challenge.getId(), LocalDate.now(), ExpPoints.THIRTY_DAY)).thenReturn(false);
 
         assertTrue(todayChallengeService.modifyTodayChallenge(todayChallengeDto));
 
@@ -182,8 +182,8 @@ public class TodayChallengeServiceImplTest {
 
         when(todayChallengeDao.updateTodayChallenge(any(TodayChallenge.class))).thenReturn(1L);
         when(challengeService.getChallengeDetail(todayChallengeDto.getChallengeId())).thenReturn(challenge);
-        when(todayChallengeDao.checkAchievementStreak(challenge.getId(), LocalDate.now(), ExpPoints.SEVEN_DAY)).thenReturn(false);
-        when(todayChallengeDao.checkAchievementStreak(challenge.getId(), LocalDate.now(), ExpPoints.THIRTY_DAY)).thenReturn(true);
+        when(todayChallengeDao.checkAchievementBonus(challenge.getId(), LocalDate.now(), ExpPoints.SEVEN_DAY)).thenReturn(false);
+        when(todayChallengeDao.checkAchievementBonus(challenge.getId(), LocalDate.now(), ExpPoints.THIRTY_DAY)).thenReturn(true);
 
         assertTrue(todayChallengeService.modifyTodayChallenge(todayChallengeDto));
 

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
@@ -188,7 +188,7 @@ public class TodayChallengeServiceImplTest {
         assertTrue(todayChallengeService.modifyTodayChallenge(todayChallengeDto));
 
         verify(userService, times(1)).modifyUserExp(challenge.getUserId(), ExpPoints.THIRTY_DAY_STREAK_EXP);
-        verify(userService, never()).modifyUserExp(challenge.getUserId(), ExpPoints.DAILY_ACHIVEMENT_EXP);
+        verify(userService, times(1)).modifyUserExp(challenge.getUserId(), ExpPoints.DAILY_ACHIVEMENT_EXP);
         verify(userService, never()).modifyUserExp(challenge.getUserId(), ExpPoints.SEVEN_DAY_STREAK_EXP);
     }
     @Test

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
@@ -3,12 +3,26 @@ package com.him.fpjt.him_backend.exercise.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.him.fpjt.him_backend.common.constants.ExpPoints;
 import com.him.fpjt.him_backend.exercise.dao.TodayChallengeDao;
+import com.him.fpjt.him_backend.exercise.domain.Challenge;
+import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
+import com.him.fpjt.him_backend.exercise.domain.ExerciseType;
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
+import com.him.fpjt.him_backend.exercise.dto.TodayChallengeDto;
+import com.him.fpjt.him_backend.user.service.UserService;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.NoSuchElementException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +36,8 @@ public class TodayChallengeServiceImplTest {
     private TodayChallengeDao todayChallengeDao;
     @Mock
     private ChallengeService challengeService;
+    @Mock
+    private UserService userService;
     @InjectMocks
     private TodayChallengeServiceImpl todayChallengeService;
     @BeforeEach
@@ -49,7 +65,6 @@ public class TodayChallengeServiceImplTest {
         TodayChallenge todayChallenge = new TodayChallenge(0, 1L, LocalDate.now());
         when(challengeService.existsChallengeById(1L)).thenReturn(false);
 
-        // when & then: 예외 검증
         assertThrows(IllegalArgumentException.class,
                 () -> todayChallengeService.createTodayChallenge(todayChallenge),
                 "존재하지 않는 챌린지 id 입니다."
@@ -96,3 +111,17 @@ public class TodayChallengeServiceImplTest {
         assertThrows(NoSuchElementException.class, () -> todayChallengeService.getTodayChallengeById(1L));
     }
 }
+    @Test
+    @DisplayName("오늘의 챌린지 목표를 달성하지 못했을 시, 경험치 3EXP를 차감한다.")
+    void modifyUnachievementTodayChallenge() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        Challenge challenge = new Challenge(1L, ChallengeStatus.ONGOING, ExerciseType.SQUAT, LocalDate.now(), LocalDate.now(), 10L, 0,1L);
+        TodayChallenge unachievedTodayChallenge = new TodayChallenge(1L, 5L, 1L, yesterday);
+
+        when(todayChallengeDao.findUnachievedChallenges(yesterday)).thenReturn(List.of(unachievedTodayChallenge));
+        when(challengeService.getChallengeDetail(unachievedTodayChallenge.getChallengeId())).thenReturn(challenge);
+        when(userService.modifyUserExp(anyLong(), eq(ExpPoints.DAILY_PENALTY_EXP))).thenReturn(true);
+
+        todayChallengeService.modifyUnachievementTodayChallenge();
+        verify(userService).modifyUserExp(challenge.getUserId(), ExpPoints.DAILY_PENALTY_EXP);
+    }


### PR DESCRIPTION
## 연관된 이슈

> resolve #25 

## 작업 내용 
> 챌린지 운동 결과 업데이트 및 경험치 반영에 대한 기능을 추가하였습니다.
> - 운동 횟수 업데이트 : 오늘의 운동 횟수를 업데이트 한 후 목표 달성 여부를 파악하여 이를 경험치에 반영하였습니다.
>  - 오늘의 목표 횟수 달성 시 5 exp 추가, 7일 연속 목표 달성 시, 10 exp 추가, 30일 연속 목표 달성 시, 100 exp 추가
> 단, 이때 연속 목표를 달성한 경우, 오늘의 목표 횟수 경험치는 추가 되지 않고 연속 목표 경험치만 부여한다. 
> 연속 목표 달성 후 다음날 또 목표를 달성 할 경우 오늘의 목표 횟수 경험치가 부여된다. 
> (ex 8일 연속 목표 달성의 경우 경험치 5exp 추가)
> -  스케줄러를 사용하여 새벽 1시 기준으로 전날 목표 횟수를 미달성한 사용자의 경험치를 3exp 차감하였습니다.

## 리뷰 요구사항 (선택)
> 목표 달성 실패 시 경험치를 차감하는 로직을 구현하는 과정에서 개선하면 좋을 부분들이 보여 리뷰 요청드립니다. 
>
> 현재 저희 기능은 클라이언트에서 오늘의 챌린지 생성 요청을 보내야 오늘 날짜의 데이터가 생성됩니다. 이 경우 목표 달성을 실패한 챌린지를 찾는 과정에서 2번의 데이터 조회가 필요합니다. 
>
> ( `modifyUnachievementTodayChallenge` 메서드를 확인하시면 목표를 달성하지 못한 todaychallenge 데이터(`unachievedTodayChallenges`)와 오늘 날짜의 todaychallenge 테이블을 생성하지 못한 challenge 데이터(`missingChallenges`) 를 모두 찾아야 하는 방식으로 구현됩니다. )
>
> 좀 더 일괄적인 처리를 위해서 특정 시점에 오늘 날짜의 오늘의 챌린지 데이터를 일괄적으로 생성하면 1번의 데이터 조회만으로 처리가 가능하여 그러한 방식으로 코드를 수정하고자 하는데 리뷰어님께서는 어떻게 생각하시는지 궁금합니다.
