### PR TITLE
출석 여부에 따른 경험치 반영

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/common/constants/ExpPoints.java
+++ b/src/main/java/com/him/fpjt/him_backend/common/constants/ExpPoints.java
@@ -8,6 +8,8 @@ public class ExpPoints {
     public static final int SEVEN_DAY = 7;
     public static final int THIRTY_DAY = 30;
 
+    public static final int DAILY_ATTENDANCE_EXP = 1;
+
     public static final int GAME_EASY_MODE = 5;
     public static final int GAME_MEDIUM_MODE = 10;
     public static final int GAME_HARD_MODE = 20;

--- a/src/main/java/com/him/fpjt/him_backend/user/controller/AttendanceController.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/controller/AttendanceController.java
@@ -1,0 +1,37 @@
+package com.him.fpjt.him_backend.user.controller;
+
+import com.him.fpjt.him_backend.user.domain.Attendance;
+import com.him.fpjt.him_backend.user.service.AttendenceService;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/attendance")
+public class AttendanceController {
+    private AttendenceService attendenceService;
+
+    public AttendanceController(AttendenceService attendenceService) {
+        this.attendenceService = attendenceService;
+    }
+
+    @GetMapping("/check/{userId}")
+    public ResponseEntity<String> setAttendanceStatus(@PathVariable("userId") long userId){
+        try {
+            attendenceService.setAttendanceStatus(userId, LocalDate.now());
+            attendenceService.addAttendanceExp(userId);
+            return ResponseEntity.ok().build();
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/him/fpjt/him_backend/user/controller/AttendanceController.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/controller/AttendanceController.java
@@ -34,4 +34,17 @@ public class AttendanceController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }
     }
+    @GetMapping("{userId}")
+    public ResponseEntity<?> getMonthlyAttendance(@PathVariable("userId") long userId,
+                                                @RequestParam("year") int year,
+                                                @RequestParam("month") int month) {
+        try {
+            List<Attendance> attendances = attendenceService.getMonthlyAttendance(userId, year, month);
+            return ResponseEntity.ok().body(attendances);
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/dao/AttendanceDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/dao/AttendanceDao.java
@@ -2,8 +2,10 @@ package com.him.fpjt.him_backend.user.dao;
 
 import com.him.fpjt.him_backend.user.domain.Attendance;
 import java.time.LocalDate;
+import java.util.List;
 
 public interface AttendanceDao {
     int insertAttendance(Attendance attendance);
     int updateAttendanceStatus(long userId, LocalDate attendDt);
+    List<Attendance> selectAttendanceByUserIdAndDateRange(long userId, LocalDate startOfMonth, LocalDate endOfMonth);
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/dao/AttendanceDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/dao/AttendanceDao.java
@@ -1,0 +1,7 @@
+package com.him.fpjt.him_backend.user.dao;
+
+import com.him.fpjt.him_backend.user.domain.Attendance;
+
+public interface AttendanceDao {
+    int insertAttendance(Attendance attendance);
+}

--- a/src/main/java/com/him/fpjt/him_backend/user/dao/AttendanceDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/dao/AttendanceDao.java
@@ -1,7 +1,9 @@
 package com.him.fpjt.him_backend.user.dao;
 
 import com.him.fpjt.him_backend.user.domain.Attendance;
+import java.time.LocalDate;
 
 public interface AttendanceDao {
     int insertAttendance(Attendance attendance);
+    int updateAttendanceStatus(long userId, LocalDate attendDt);
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
@@ -1,6 +1,9 @@
 package com.him.fpjt.him_backend.user.dao;
 
+import java.util.List;
+
 public interface UserDao {
 
     int updateUserExp(long userId, long expPoints);
+    List<Long> selectAllUserIds();
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/domain/Attendance.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/domain/Attendance.java
@@ -1,19 +1,21 @@
 package com.him.fpjt.him_backend.user.domain;
 
 import java.time.LocalDate;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
 
 @Getter
 @ToString
-public class Attendence {
+@AllArgsConstructor
+public class Attendance {
     private long id;
     private LocalDate attendDt;
     private boolean isAttended;
     private long userId;
 
-    public Attendence(long userId) {
+    public Attendance(long userId) {
         this.userId = userId;
         this.attendDt = LocalDate.now();
         this.isAttended = false; //게임 1개를 진행하면 true

--- a/src/main/java/com/him/fpjt/him_backend/user/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/AttendanceServiceImpl.java
@@ -1,0 +1,33 @@
+package com.him.fpjt.him_backend.user.service;
+
+import com.him.fpjt.him_backend.common.constants.ExpPoints;
+import com.him.fpjt.him_backend.user.dao.AttendanceDao;
+import com.him.fpjt.him_backend.user.domain.Attendance;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AttendanceServiceImpl implements AttendenceService{
+    private AttendanceDao attendanceDao;
+    private UserService userService;
+
+    public AttendanceServiceImpl(AttendanceDao attendanceDao, UserService userService) {
+        this.attendanceDao = attendanceDao;
+        this.userService = userService;
+    }
+
+    @Override
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void generateDailyAttendance() {
+        List<Long> userIds = userService.getAllUserIds();
+        for (Long userId : userIds) {
+            attendanceDao.insertAttendance(new Attendance(userId));
+        }
+    }
+}

--- a/src/main/java/com/him/fpjt/him_backend/user/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/AttendanceServiceImpl.java
@@ -30,4 +30,10 @@ public class AttendanceServiceImpl implements AttendenceService{
             attendanceDao.insertAttendance(new Attendance(userId));
         }
     }
+
+    @Override
+    @Transactional
+    public void addAttendanceExp(long userId) throws Exception {
+        userService.modifyUserExp(userId, ExpPoints.DAILY_ATTENDANCE_EXP);
+    }
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/AttendanceServiceImpl.java
@@ -36,4 +36,13 @@ public class AttendanceServiceImpl implements AttendenceService{
     public void addAttendanceExp(long userId) throws Exception {
         userService.modifyUserExp(userId, ExpPoints.DAILY_ATTENDANCE_EXP);
     }
+
+    @Override
+    @Transactional
+    public void setAttendanceStatus(long userId, LocalDate attendDt) {
+        int updatedRow = attendanceDao.updateAttendanceStatus(userId, attendDt);
+        if (updatedRow == 0) {
+            throw new NoSuchElementException("존재히지 않는 회원입니다.");
+        }
+    }
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/AttendanceServiceImpl.java
@@ -45,4 +45,15 @@ public class AttendanceServiceImpl implements AttendenceService{
             throw new NoSuchElementException("존재히지 않는 회원입니다.");
         }
     }
+
+    @Override
+    public List<Attendance> getMonthlyAttendance(long userId, int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        List<Attendance> attendances = attendanceDao.selectAttendanceByUserIdAndDateRange(userId,
+                yearMonth.atDay(1), yearMonth.atEndOfMonth());
+        if (attendances == null || attendances.isEmpty()) {
+            throw new NoSuchElementException("해당 회원의 출석 기록이 존재하지 않습니다.");
+        }
+        return attendances;
+    }
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/AttendenceService.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/AttendenceService.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface AttendenceService {
     void generateDailyAttendance();
     void addAttendanceExp(long userId) throws Exception;
+    void setAttendanceStatus(long userId, LocalDate attendDt);
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/AttendenceService.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/AttendenceService.java
@@ -8,4 +8,5 @@ public interface AttendenceService {
     void generateDailyAttendance();
     void addAttendanceExp(long userId) throws Exception;
     void setAttendanceStatus(long userId, LocalDate attendDt);
+    List<Attendance> getMonthlyAttendance(long userId, int year, int month);
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/AttendenceService.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/AttendenceService.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface AttendenceService {
     void generateDailyAttendance();
+    void addAttendanceExp(long userId) throws Exception;
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/AttendenceService.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/AttendenceService.java
@@ -1,0 +1,9 @@
+package com.him.fpjt.him_backend.user.service;
+
+import com.him.fpjt.him_backend.user.domain.Attendance;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface AttendenceService {
+    void generateDailyAttendance();
+}

--- a/src/main/java/com/him/fpjt/him_backend/user/service/UserService.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/UserService.java
@@ -1,6 +1,9 @@
 package com.him.fpjt.him_backend.user.service;
 
+import java.util.List;
+
 public interface UserService {
 
     void modifyUserExp(long userId, long expPoints) throws Exception;
+    List<Long> getAllUserIds();
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.him.fpjt.him_backend.user.service;
 
 import com.him.fpjt.him_backend.user.dao.UserDao;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,5 +21,10 @@ public class UserServiceImpl implements UserService {
         if (updateResult == 0) {
             throw new UnsupportedOperationException("사용자 경험치 업데이트에 실패했습니다.");
         }
+    }
+
+    @Override
+    public List<Long> getAllUserIds() {
+        return userDao.selectAllUserIds();
     }
 }

--- a/src/main/resources/mappers/AttendanceMapper.xml
+++ b/src/main/resources/mappers/AttendanceMapper.xml
@@ -11,4 +11,9 @@
     SET is_attended = true
     WHERE user_id = #{userId} AND attend_dt = #{attendDt}
   </update>
+  <select id="selectAttendanceByUserIdAndDateRange" parameterType="map" resultType="Attendance">
+    SELECT * FROM attendance
+    WHERE user_id = #{userId}
+      AND attend_dt BETWEEN #{startOfMonth} AND #{endOfMonth}
+  </select>
 </mapper>

--- a/src/main/resources/mappers/AttendanceMapper.xml
+++ b/src/main/resources/mappers/AttendanceMapper.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.him.fpjt.him_backend.user.dao.AttendanceDao">
+  <insert id="insertAttendance" parameterType="Attendance">
+    INSERT INTO attendance (attend_dt, is_attended, user_id)
+    VALUES (#{attendDt}, #{isAttended}, #{userId})
+  </insert>
+</mapper>

--- a/src/main/resources/mappers/AttendanceMapper.xml
+++ b/src/main/resources/mappers/AttendanceMapper.xml
@@ -6,4 +6,9 @@
     INSERT INTO attendance (attend_dt, is_attended, user_id)
     VALUES (#{attendDt}, #{isAttended}, #{userId})
   </insert>
+  <update id="updateAttendanceStatus" parameterType="map" >
+    UPDATE attendance
+    SET is_attended = true
+    WHERE user_id = #{userId} AND attend_dt = #{attendDt}
+  </update>
 </mapper>

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -9,4 +9,7 @@
         SET exp = exp + #{expPoints}
         WHERE id = #{userId}
     </update>
+    <select id="selectAllUserIds" resultType="long">
+        SELECT id FROM user
+    </select>
 </mapper>

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/AttendanceServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/AttendanceServiceImplTest.java
@@ -61,4 +61,29 @@ public class AttendanceServiceImplTest {
 
         verify(userService, times(1)).modifyUserExp(userId, ExpPoints.DAILY_ATTENDANCE_EXP);
     }
+
+    @Test
+    @DisplayName("오늘의 출석 칼럼의 출석 상태를 true로 수정한다.")
+    void setAttendanceStatus() {
+        long userId = 1L;
+        LocalDate attendDate = LocalDate.now();
+        when(attendanceDao.updateAttendanceStatus(userId, attendDate)).thenReturn(1);
+
+        attendanceService.setAttendanceStatus(userId, attendDate);
+
+        verify(attendanceDao, times(1)).updateAttendanceStatus(userId, attendDate);
+    }
+
+    @Test
+    @DisplayName("출석 상태 업데이트 실패 시, 예외가 발생한다.")
+    void setAttendanceStatus_UserNotFound() {
+        long userId = 1L;
+        LocalDate attendDate = LocalDate.now();
+        when(attendanceDao.updateAttendanceStatus(userId, attendDate)).thenReturn(0);
+
+        assertThrows(NoSuchElementException.class, () ->
+                attendanceService.setAttendanceStatus(userId, attendDate)
+        );
+    }
+
 }

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/AttendanceServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/AttendanceServiceImplTest.java
@@ -51,4 +51,14 @@ public class AttendanceServiceImplTest {
             verify(attendanceDao, times(3)).insertAttendance(any(Attendance.class));
         }
     }
+
+    @Test
+    @DisplayName("사용자의 출석 경험치 1EXP를 추가한다.")
+    void addAttendanceExp() throws Exception {
+        long userId = 1L;
+
+        attendanceService.addAttendanceExp(1L);
+
+        verify(userService, times(1)).modifyUserExp(userId, ExpPoints.DAILY_ATTENDANCE_EXP);
+    }
 }

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/AttendanceServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/AttendanceServiceImplTest.java
@@ -1,0 +1,54 @@
+package com.him.fpjt.him_backend.exercise.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.him.fpjt.him_backend.common.constants.ExpPoints;
+import com.him.fpjt.him_backend.user.dao.AttendanceDao;
+import com.him.fpjt.him_backend.user.domain.Attendance;
+import com.him.fpjt.him_backend.user.service.AttendanceServiceImpl;
+import com.him.fpjt.him_backend.user.service.UserService;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class AttendanceServiceImplTest {
+    @Mock
+    private AttendanceDao attendanceDao;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private AttendanceServiceImpl attendanceService;
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("사용자 목록을 기반으로 오늘 날짜의 출석 칼럼을 생성한다.")
+    void generateDailyAttendance() {
+        List<Long> userIds = Arrays.asList(1L, 2L, 3L);
+        when(userService.getAllUserIds()).thenReturn(userIds);
+
+        attendanceService.generateDailyAttendance();
+
+        for (Long userId : userIds) {
+            verify(attendanceDao, times(3)).insertAttendance(any(Attendance.class));
+        }
+    }
+}

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/AttendanceServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/AttendanceServiceImplTest.java
@@ -86,4 +86,39 @@ public class AttendanceServiceImplTest {
         );
     }
 
+    @Test
+    @DisplayName("해당 월의 출석 리스트를 조회한다.")
+    void getMonthlyAttendance() {
+        long userId = 1L;
+        int year = 2024;
+        int month = 10;
+        YearMonth yearMonth = YearMonth.of(year, month);
+        List<Attendance> expectedAttendances = Arrays.asList(
+                new Attendance(1L, yearMonth.atDay(1), true, userId),
+                new Attendance(2L, yearMonth.atDay(2), false, userId)
+        );
+
+        when(attendanceDao.selectAttendanceByUserIdAndDateRange(userId, yearMonth.atDay(1), yearMonth.atEndOfMonth()))
+                .thenReturn(expectedAttendances);
+
+        List<Attendance> actualAttendances = attendanceService.getMonthlyAttendance(userId, year, month);
+
+        assertEquals(expectedAttendances, actualAttendances);
+    }
+
+    @Test
+    @DisplayName("출석 기록이 없는 경우, 예외가 발생한다.")
+    void getMonthlyAttendance_NoAttendanceRecords() {
+        long userId = 1L;
+        int year = 2024;
+        int month = 10;
+        YearMonth yearMonth = YearMonth.of(year, month);
+
+        when(attendanceDao.selectAttendanceByUserIdAndDateRange(userId, yearMonth.atDay(1), yearMonth.atEndOfMonth()))
+                .thenReturn(Collections.emptyList());
+
+        assertThrows(NoSuchElementException.class, () ->
+                attendanceService.getMonthlyAttendance(userId, year, month)
+        );
+    }
 }


### PR DESCRIPTION
## 연관된 이슈

> resolve #35 

## 작업 내용

> 오늘 날짜의 출석 칼럼 생성 및 출석 여부에 따른 경험치 반영, 출석 리스트 조회 기능을 추가하였습니다.
> - 오늘 날짜의 출석 칼럼 생성 : 스케줄러를 이용하여 자정 기점으로 모든 사용자의 오늘 날짜 출석 칼럼이 생성됩니다.
> - 출석 체크 시, 출석 상태 업데이트 및 출석 경험치 1exp 부여 
> - 캘린더 생성을 위해 userId와 year, month에 따라 한 달의 출석 리스트 조회

