### PR TITLE
챌린지 수정 및 오늘 날짜 챌린지 상태 변경 기능 추가

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/ChallengeController.java
@@ -2,14 +2,17 @@ package com.him.fpjt.him_backend.exercise.controller;
 
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
 import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
+import com.him.fpjt.him_backend.exercise.dto.ChallengeDto;
 import com.him.fpjt.him_backend.exercise.service.ChallengeService;
 import java.util.List;
+import java.util.NoSuchElementException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -50,6 +53,19 @@ public class ChallengeController {
         return challenges != null ?
                 ResponseEntity.ok().body(challenges):
                 ResponseEntity.status(HttpStatus.NOT_FOUND).body("일치하는 챌린지가 없습니다.");
+    }
+    @PutMapping("/{challengeId}")
+    public ResponseEntity<String> modifyChallenge(@PathVariable("challengeId") long id,
+                                            @RequestBody ChallengeDto challenge) {
+        try {
+            challengeService.modifyChallenge(id, challenge);
+            ResponseEntity.ok().build();
+        } catch (NoSuchElementException e) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        } catch (IllegalStateException e) {
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
+        return null;
     }
     @DeleteMapping("/{challengeId}")
     public ResponseEntity<String> removeChallenge(@PathVariable("challengeId") long id) {

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
@@ -14,5 +14,6 @@ public interface ChallengeDao {
     public int updateChallengeAchieveCnt(long id);
     public boolean existsChallengeByStartDate(LocalDate date);
     public boolean existsChallengeByEndDate(LocalDate date);
+    public int updateChallengeStatus(LocalDate today);
     public List<Challenge> findChallengesWithoutTodayRecord(LocalDate yesterday);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
@@ -3,11 +3,10 @@ package com.him.fpjt.him_backend.exercise.dao;
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 
 public interface ChallengeDao {
     public int insertChallenge(Challenge challenge);
-    public List<Challenge> selectChallengesByStatusAndUserId(Map<String, Object> params);
+    public List<Challenge> selectChallengesByStatusAndUserId(long userId, String status);
     public Challenge selectChallenge(long id);
     public int deleteChallenge(long id);
     public int deleteTodayChallengeByChallengeId(long id);

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
@@ -16,4 +16,5 @@ public interface ChallengeDao {
     public boolean existsChallengeByEndDate(LocalDate date);
     public int updateChallengeStatus(LocalDate today);
     public List<Challenge> findChallengesWithoutTodayRecord(LocalDate yesterday);
+    public int updateChallenge(Challenge challenge);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
@@ -12,5 +12,7 @@ public interface ChallengeDao {
     public int deleteTodayChallengeByChallengeId(long id);
     public boolean existsChallengeById(long id);
     public int updateChallengeAchieveCnt(long id);
+    public boolean existsChallengeByStartDate(LocalDate date);
+    public boolean existsChallengeByEndDate(LocalDate date);
     public List<Challenge> findChallengesWithoutTodayRecord(LocalDate yesterday);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/domain/Challenge.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/domain/Challenge.java
@@ -29,4 +29,20 @@ public class Challenge {
         this.achievedCnt = 0;
         this.userId = userId;
     }
+
+    public void updateType(ExerciseType type) {
+        this.type = type;
+    }
+
+    public void updateStartDt(LocalDate startDt) {
+        this.startDt = startDt;
+    }
+
+    public void updateEndDt(LocalDate endDt) {
+        this.endDt = endDt;
+    }
+
+    public void updateGoalCnt(long goalCnt) {
+        this.goalCnt = goalCnt;
+    }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dto/ChallengeDto.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dto/ChallengeDto.java
@@ -1,0 +1,21 @@
+package com.him.fpjt.him_backend.exercise.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
+import com.him.fpjt.him_backend.exercise.domain.ExerciseType;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ChallengeDto {
+    private ExerciseType type;
+    private LocalDate startDt;
+    private LocalDate endDt;
+    private long goalCnt;
+}

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
@@ -2,6 +2,7 @@ package com.him.fpjt.him_backend.exercise.service;
 
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
 import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
+import com.him.fpjt.him_backend.exercise.dto.ChallengeDto;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -9,6 +10,7 @@ public interface ChallengeService {
     public boolean createChallenge(Challenge challenge);
     public List<Challenge> getChallengeByStatusAndUserId(long userId, ChallengeStatus status);
     public Challenge getChallengeDetail(long id);
+    public boolean modifyChallenge(long id, ChallengeDto challengeDto);
     public boolean removeChallenge(long id);
     public boolean existsChallengeById(long id);
     public boolean modifyChallengeAchieveCnt(long id);

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeService.java
@@ -13,4 +13,5 @@ public interface ChallengeService {
     public boolean existsChallengeById(long id);
     public boolean modifyChallengeAchieveCnt(long id);
     public List<Challenge> findChallengesWithoutTodayRecord(LocalDate yesterday);
+    public void modifyChallengeStatus();
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
@@ -86,7 +86,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     @Override
-    @Scheduled(cron = "50 59 23 * * ?")
+    @Scheduled(cron = "10 0 0 * * ?")
     public void modifyChallengeStatus() {
         LocalDate today = LocalDate.now();
         if (challengeDao.existsChallengeByStartDate(today) || challengeDao.existsChallengeByEndDate(today)) {

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
@@ -4,10 +4,9 @@ import com.him.fpjt.him_backend.exercise.dao.ChallengeDao;
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
 import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
 import java.time.LocalDate;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 @Slf4j
@@ -26,10 +25,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     @Override
     public List<Challenge> getChallengeByStatusAndUserId(long userId, ChallengeStatus status) {
-        Map<String, Object> params = new HashMap<>();
-        params.put("userId", userId);
-        params.put("status", ChallengeStatus.ONGOING.name());
-        return challengeDao.selectChallengesByStatusAndUserId(params);
+        return challengeDao.selectChallengesByStatusAndUserId(userId, status.name());
     }
 
     @Override

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
@@ -55,4 +55,14 @@ public class ChallengeServiceImpl implements ChallengeService {
     public List<Challenge> findChallengesWithoutTodayRecord(LocalDate yesterday) {
         return challengeDao.findChallengesWithoutTodayRecord(yesterday);
     }
+
+    @Override
+    @Scheduled(cron = "50 59 23 * * ?")
+    public void modifyChallengeStatus() {
+        LocalDate today = LocalDate.now();
+        if (challengeDao.existsChallengeByStartDate(today) || challengeDao.existsChallengeByEndDate(today)) {
+            int changedCount = challengeDao.updateChallengeStatus(today);
+            log.info("updated challenge count : {}", changedCount);
+        }
+    }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
@@ -3,8 +3,10 @@ package com.him.fpjt.him_backend.exercise.service;
 import com.him.fpjt.him_backend.exercise.dao.ChallengeDao;
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
 import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
+import com.him.fpjt.him_backend.exercise.dto.ChallengeDto;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -31,6 +33,33 @@ public class ChallengeServiceImpl implements ChallengeService {
     @Override
     public Challenge getChallengeDetail(long id) {
         return challengeDao.selectChallenge(id);
+    }
+
+    @Override
+    public boolean modifyChallenge(long id, ChallengeDto challengeDto) {
+        Challenge Challenge = findChallenge(id);
+        modifyChallengeFields(challengeDto, Challenge);
+
+        int result = challengeDao.updateChallenge(Challenge);
+        if (result == 0) {
+            throw new IllegalStateException("챌린지 업데이트에 실패했습니다.");
+        }
+        return true;
+    }
+
+    private static void modifyChallengeFields(ChallengeDto challengeDto, Challenge Challenge) {
+        Challenge.updateType(challengeDto.getType());
+        Challenge.updateStartDt(challengeDto.getStartDt());
+        Challenge.updateEndDt(challengeDto.getEndDt());
+        Challenge.updateGoalCnt(challengeDto.getGoalCnt());
+    }
+
+    private Challenge findChallenge(long challengeId) {
+        Challenge foundChallenge = getChallengeDetail(challengeId);
+        if (foundChallenge == null) {
+            throw new NoSuchElementException("없는 챌린지 입니다.");
+        }
+        return foundChallenge;
     }
 
     @Override

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -41,6 +41,16 @@
              SELECT * FROM challenge WHERE end_dt = #{today}
              )
   </select>
+  <update id="updateChallengeStatus" parameterType="java.time.LocalDate">
+    UPDATE challenge
+    SET status =
+          CASE
+            WHEN end_dt = #{today} THEN 'DONE'
+            WHEN start_dt = #{today} THEN 'ONGOING'
+            ELSE status
+            END
+    WHERE start_dt = #{today} OR end_dt = #{today}
+  </update>
   <select id="findChallengesWithoutTodayRecord" parameterType="java.time.LocalDate" resultType="Challenge">
     SELECT *
     FROM challenge c

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -31,6 +31,16 @@
   <update id="updateChallengeAchieveCnt" parameterType="long">
     UPDATE challenge SET achieve_cnt = achieve_cnt + 1 WHERE id = #{id}
   </update>
+  <select id="existsChallengeByStartDate" parameterType="java.time.LocalDate" resultType="boolean">
+    SELECT EXISTS (
+        SELECT * FROM challenge WHERE start_dt = #{today}
+    )
+  </select>
+  <select id="existsChallengeByEndDate" parameterType="java.time.LocalDate" resultType="boolean">
+    SELECT EXISTS (
+             SELECT * FROM challenge WHERE end_dt = #{today}
+             )
+  </select>
   <select id="findChallengesWithoutTodayRecord" parameterType="java.time.LocalDate" resultType="Challenge">
     SELECT *
     FROM challenge c

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -62,4 +62,9 @@
           AND tc.date = #{yesterday}
       )
   </select>
+  <update id="updateChallenge" parameterType="Challenge">
+    UPDATE challenge
+    SET type = #{type}, start_dt = #{startDt}, end_dt = #{endDt}, goal_cnt = #{goalCnt}
+    WHERE id = #{id}
+  </update>
 </mapper>

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
@@ -70,12 +70,14 @@ public class ChallegeServiceImplTest {
     @Test
     @DisplayName("status와 userId에 따라 챌린지 목록을 조회한다.")
     void getChallengeByStatusAndUserId() {
-        when(challengeDao.selectChallengesByStatusAndUserId(anyMap())).thenReturn(List.of(mockChallenge));
+        long userId = 1L;
+        String status = ChallengeStatus.ONGOING.name();
+        when(challengeDao.selectChallengesByStatusAndUserId(userId, status)).thenReturn(List.of(mockChallenge));
 
-        List<Challenge> challenges = challengeService.getChallengeByStatusAndUserId(1L, ChallengeStatus.ONGOING);
+        List<Challenge> challenges = challengeService.getChallengeByStatusAndUserId(userId, ChallengeStatus.ONGOING);
 
         assertEquals(1, challenges.size());
-        verify(challengeDao, times(1)).selectChallengesByStatusAndUserId(anyMap());
+        verify(challengeDao, times(1)).selectChallengesByStatusAndUserId(userId, status);
     }
 
     @Test

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -104,5 +103,36 @@ public class ChallegeServiceImplTest {
         when(challengeDao.deleteTodayChallengeByChallengeId(1L)).thenReturn(1);
         when(challengeDao.deleteChallenge(1L)).thenReturn(0);
         assertFalse(challengeService.removeChallenge(1L));
+    }
+
+    @Test
+    @DisplayName("종료일이 오늘인 챌린지의 상태를 done으로 업데이트 한다.")
+    void modifyChallengeStatus_done() {
+        LocalDate today = LocalDate.now();
+        when(challengeDao.existsChallengeByStartDate(today)).thenReturn(false);
+        when(challengeDao.existsChallengeByEndDate(today)).thenReturn(true);
+
+        when(challengeDao.updateChallengeStatus(today)).thenReturn(3);
+
+        challengeService.modifyChallengeStatus();
+
+        verify(challengeDao).existsChallengeByStartDate(today);
+        verify(challengeDao).existsChallengeByEndDate(today);
+        verify(challengeDao).updateChallengeStatus(today);
+    }
+
+    @Test
+    @DisplayName("시작일이 오늘인 챌린지의 상태를 ongoing으로 업데이트 한다.")
+    void modifyChallengeStatus_onging() {
+        LocalDate today = LocalDate.now();
+        when(challengeDao.existsChallengeByStartDate(today)).thenReturn(true);
+        when(challengeDao.existsChallengeByEndDate(today)).thenReturn(false);
+
+        when(challengeDao.updateChallengeStatus(today)).thenReturn(3);
+
+        challengeService.modifyChallengeStatus();
+
+        verify(challengeDao).existsChallengeByStartDate(today);
+        verify(challengeDao).updateChallengeStatus(today);
     }
 }


### PR DESCRIPTION
## 연관된 이슈

> resolve #38 

## 작업 내용

> 챌린지 수정 및 오늘 날짜 챌린지 상태 변경 기능을 추가합니다.
> - 오전 12시 10초를 기점으로 오늘이 챌린지 시작일인 챌린지 상태를 `ONGOING`으로 수정하고, 
오늘이 챌린지 종료일인 챌린지 상태를 `DONE`으로 수정하는 스케줄러를 추가했습니다.
> -  운동 종류와 시작일, 종료일, 목표 갯수를 바꾸는 챌린지 수정 기능을 추가했습니다.
