### PR TITLE
사용자 정보 조회 및 수정 기능 추가

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/user/controller/UserController.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/controller/UserController.java
@@ -1,12 +1,15 @@
 package com.him.fpjt.him_backend.user.controller;
 
 import com.him.fpjt.him_backend.user.dto.UserInfoDto;
+import com.him.fpjt.him_backend.user.dto.UserModifyDto;
 import com.him.fpjt.him_backend.user.service.UserService;
 import java.util.NoSuchElementException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,6 +29,18 @@ public class UserController {
             return ResponseEntity.ok().body(userInfoDto);
         } catch (NoSuchElementException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+    @PutMapping("/{userId}")
+    public ResponseEntity<?> modifyUserInfo(@PathVariable("userId") long id,
+                                    @RequestBody UserModifyDto userModifyDto) {
+        try {
+            userService.modifyUserInfo(id, userModifyDto);
+            return ResponseEntity.ok().build();
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/controller/UserController.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/controller/UserController.java
@@ -1,0 +1,31 @@
+package com.him.fpjt.him_backend.user.controller;
+
+import com.him.fpjt.him_backend.user.dto.UserInfoDto;
+import com.him.fpjt.him_backend.user.service.UserService;
+import java.util.NoSuchElementException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user")
+public class UserController {
+    private UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<?> getUserInfo(@PathVariable("userId") long id) {
+        try {
+            UserInfoDto userInfoDto = userService.getUserById(id);
+            return ResponseEntity.ok().body(userInfoDto);
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/him/fpjt/him_backend/user/controller/UserController.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/controller/UserController.java
@@ -23,19 +23,19 @@ public class UserController {
     }
 
     @GetMapping("/{userId}")
-    public ResponseEntity<?> getUserInfo(@PathVariable("userId") long id) {
+    public ResponseEntity<?> getUserInfo(@PathVariable("userId") long userId) {
         try {
-            UserInfoDto userInfoDto = userService.getUserById(id);
+            UserInfoDto userInfoDto = userService.getUserById(userId);
             return ResponseEntity.ok().body(userInfoDto);
         } catch (NoSuchElementException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }
     }
     @PutMapping("/{userId}")
-    public ResponseEntity<?> modifyUserInfo(@PathVariable("userId") long id,
+    public ResponseEntity<?> modifyUserInfo(@PathVariable("userId") long userId,
                                     @RequestBody UserModifyDto userModifyDto) {
         try {
-            userService.modifyUserInfo(id, userModifyDto);
+            userService.modifyUserInfo(userId, userModifyDto);
             return ResponseEntity.ok().build();
         } catch (NoSuchElementException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());

--- a/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
@@ -1,9 +1,11 @@
 package com.him.fpjt.him_backend.user.dao;
 
+import com.him.fpjt.him_backend.user.domain.User;
 import java.util.List;
 
 public interface UserDao {
 
     int updateUserExp(long id, long expPoints);
     List<Long> selectAllUserIds();
+    User selectUserById(long id);
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
@@ -8,4 +8,5 @@ public interface UserDao {
     int updateUserExp(long id, long expPoints);
     List<Long> selectAllUserIds();
     User selectUserById(long id);
+    int updateUserInfo(User user);
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
@@ -5,8 +5,8 @@ import java.util.List;
 
 public interface UserDao {
 
-    int updateUserExp(long id, long expPoints);
+    int updateUserExp(long userId, long expPoints);
     List<Long> selectAllUserIds();
-    User selectUserById(long id);
+    User selectUserById(long userId);
     int updateUserInfo(User user);
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
@@ -4,6 +4,6 @@ import java.util.List;
 
 public interface UserDao {
 
-    int updateUserExp(long userId, long expPoints);
+    int updateUserExp(long id, long expPoints);
     List<Long> selectAllUserIds();
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/domain/User.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/domain/User.java
@@ -11,6 +11,7 @@ public class User {
     private long id;
     private String nickname;
     private String email;
+    private String password;
     private String profileImg;
     private Tier tier = Tier.IRON;
     private long exp = 0;

--- a/src/main/java/com/him/fpjt/him_backend/user/domain/User.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/domain/User.java
@@ -22,19 +22,7 @@ public class User {
         this.nickname = nickname;
     }
 
-    public void updateEmail(String email) {
-        this.email = email;
-    }
-
     public void updateProfileImg(String profileImg) {
         this.profileImg = profileImg;
-    }
-
-    public void updateTier(Tier tier) {
-        this.tier = tier;
-    }
-
-    public void updateExp(long exp) {
-        this.exp = exp;
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/dto/UserInfoDto.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/dto/UserInfoDto.java
@@ -1,0 +1,20 @@
+package com.him.fpjt.him_backend.user.dto;
+
+import com.him.fpjt.him_backend.user.domain.Tier;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserInfoDto {
+    private long id;
+    private String nickname;
+    private String email;
+    private String profileImg;
+    private Tier tier;
+    private long exp;
+}

--- a/src/main/java/com/him/fpjt/him_backend/user/dto/UserModifyDto.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/dto/UserModifyDto.java
@@ -1,0 +1,15 @@
+package com.him.fpjt.him_backend.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserModifyDto {
+    private String nickname;
+    private String profileImg;
+}

--- a/src/main/java/com/him/fpjt/him_backend/user/service/UserService.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/UserService.java
@@ -1,9 +1,11 @@
 package com.him.fpjt.him_backend.user.service;
 
+import com.him.fpjt.him_backend.user.dto.UserInfoDto;
 import java.util.List;
 
 public interface UserService {
 
     void modifyUserExp(long userId, long expPoints) throws Exception;
     List<Long> getAllUserIds();
+    UserInfoDto getUserById(long id);
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/UserService.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/UserService.java
@@ -1,6 +1,8 @@
 package com.him.fpjt.him_backend.user.service;
 
+import com.him.fpjt.him_backend.user.domain.User;
 import com.him.fpjt.him_backend.user.dto.UserInfoDto;
+import com.him.fpjt.him_backend.user.dto.UserModifyDto;
 import java.util.List;
 
 public interface UserService {
@@ -8,4 +10,5 @@ public interface UserService {
     void modifyUserExp(long userId, long expPoints) throws Exception;
     List<Long> getAllUserIds();
     UserInfoDto getUserById(long id);
+    void modifyUserInfo(long id, UserModifyDto userModifyDto);
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/UserService.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/UserService.java
@@ -9,6 +9,6 @@ public interface UserService {
 
     void modifyUserExp(long userId, long expPoints) throws Exception;
     List<Long> getAllUserIds();
-    UserInfoDto getUserById(long id);
-    void modifyUserInfo(long id, UserModifyDto userModifyDto);
+    UserInfoDto getUserById(long userId);
+    void modifyUserInfo(long userId, UserModifyDto userModifyDto);
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.him.fpjt.him_backend.user.service;
 import com.him.fpjt.him_backend.user.dao.UserDao;
 import com.him.fpjt.him_backend.user.domain.User;
 import com.him.fpjt.him_backend.user.dto.UserInfoDto;
+import com.him.fpjt.him_backend.user.dto.UserModifyDto;
 import java.util.List;
 import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
@@ -44,4 +45,20 @@ public class UserServiceImpl implements UserService {
         }
         return user;
     }
+    @Override
+    @Transactional
+    public void modifyUserInfo(long id, UserModifyDto userModifyDto) {
+        User user = verifyUserExists(id);
+        modifyUserFields(userModifyDto, user);
+        int result = userDao.updateUserInfo(user);
+        if (result == 0) {
+            throw new IllegalStateException("회원 정보 수정을 실패하였습니다.");
+        }
+    }
+
+    private static void modifyUserFields(UserModifyDto userModifyDto, User user) {
+        user.updateNickname(userModifyDto.getNickname());
+        user.updateProfileImg(userModifyDto.getProfileImg());
+    }
+
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
@@ -20,8 +20,8 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public void modifyUserExp(long id, long expPoints) {
-        int updateResult = userDao.updateUserExp(id, expPoints);
+    public void modifyUserExp(long userId, long expPoints) {
+        int updateResult = userDao.updateUserExp(userId, expPoints);
         if (updateResult == 0) {
             throw new UnsupportedOperationException("사용자 경험치 업데이트에 실패했습니다.");
         }
@@ -33,13 +33,13 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public UserInfoDto getUserById(long id) {
-        User user = verifyUserExists(id);
+    public UserInfoDto getUserById(long userId) {
+        User user = verifyUserExists(userId);
         return new UserInfoDto(user.getId(), user.getNickname(), user.getEmail(),
                 user.getProfileImg(), user.getTier(), user.getExp());
     }
-    private User verifyUserExists(long id) {
-        User user = userDao.selectUserById(id);
+    private User verifyUserExists(long userId) {
+        User user = userDao.selectUserById(userId);
         if (user == null) {
             throw new NoSuchElementException("없는 회원입니다.");
         }
@@ -47,8 +47,8 @@ public class UserServiceImpl implements UserService {
     }
     @Override
     @Transactional
-    public void modifyUserInfo(long id, UserModifyDto userModifyDto) {
-        User user = verifyUserExists(id);
+    public void modifyUserInfo(long userId, UserModifyDto userModifyDto) {
+        User user = verifyUserExists(userId);
         modifyUserFields(userModifyDto, user);
         int result = userDao.updateUserInfo(user);
         if (result == 0) {
@@ -60,5 +60,4 @@ public class UserServiceImpl implements UserService {
         user.updateNickname(userModifyDto.getNickname());
         user.updateProfileImg(userModifyDto.getProfileImg());
     }
-
 }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
@@ -16,8 +16,8 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public void modifyUserExp(long userId, long expPoints) {
-        int updateResult = userDao.updateUserExp(userId, expPoints);
+    public void modifyUserExp(long id, long expPoints) {
+        int updateResult = userDao.updateUserExp(id, expPoints);
         if (updateResult == 0) {
             throw new UnsupportedOperationException("사용자 경험치 업데이트에 실패했습니다.");
         }

--- a/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
@@ -1,7 +1,10 @@
 package com.him.fpjt.him_backend.user.service;
 
 import com.him.fpjt.him_backend.user.dao.UserDao;
+import com.him.fpjt.him_backend.user.domain.User;
+import com.him.fpjt.him_backend.user.dto.UserInfoDto;
 import java.util.List;
+import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,5 +29,19 @@ public class UserServiceImpl implements UserService {
     @Override
     public List<Long> getAllUserIds() {
         return userDao.selectAllUserIds();
+    }
+
+    @Override
+    public UserInfoDto getUserById(long id) {
+        User user = verifyUserExists(id);
+        return new UserInfoDto(user.getId(), user.getNickname(), user.getEmail(),
+                user.getProfileImg(), user.getTier(), user.getExp());
+    }
+    private User verifyUserExists(long id) {
+        User user = userDao.selectUserById(id);
+        if (user == null) {
+            throw new NoSuchElementException("없는 회원입니다.");
+        }
+        return user;
     }
 }

--- a/src/main/resources/HIM_schema.sql
+++ b/src/main/resources/HIM_schema.sql
@@ -6,16 +6,18 @@ CREATE TABLE `user`(
     `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
     `nickname` VARCHAR(255) NOT NULL,
     `email` VARCHAR(255),
+    `password` VARCHAR(255) NOT NULL,
     `profile_img` VARCHAR(255),
     `tier` VARCHAR(255) NOT NULL,
     `exp` BIGINT NOT NULL
 );
 -- user 객체에 목업 데이터 삽입
-INSERT INTO `user` (`nickname`, `email`, `profile_img`, `tier`, `exp`)
-VALUES 
-    ('Icarus', 'email_example1@gmail.com', 'img_example1.jpg', 'BRONZE', 1000),
-    ('Jay', 'email_example2@gmail.com', 'img_example2.jpg', 'MASTER', 2000),
-    ('Ollie', 'email_example3@gmail.com', 'img_example3.jpg', 'DIAMOND', 3000);
+INSERT INTO `user` (`nickname`, `email`, `password`, `profile_img`, `tier`, `exp`)
+VALUES
+    ('Icarus', 'email_example1@gmail.com', 'hashed_password1', 'img_example1.jpg', 'BRONZE', 1000),
+    ('Jay', 'email_example2@gmail.com', 'hashed_password2', 'img_example2.jpg', 'MASTER', 2000),
+    ('Ollie', 'email_example3@gmail.com', 'hashed_password3', 'img_example3.jpg', 'DIAMOND', 3000);
+
 SELECT * FROM user;
 
 CREATE TABLE `challenge`(

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -12,4 +12,7 @@
     <select id="selectAllUserIds" resultType="long">
         SELECT id FROM user
     </select>
+    <select id="selectUserById" parameterType="long" resultType="User">
+        SELECT * FROM user WHERE id = #{id}
+    </select>
 </mapper>

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -7,13 +7,13 @@
     <update id="updateUserExp" parameterType="map">
         UPDATE user
         SET exp = exp + #{expPoints}
-        WHERE id = #{id}
+        WHERE id = #{userId}
     </update>
     <select id="selectAllUserIds" resultType="long">
         SELECT id FROM user
     </select>
     <select id="selectUserById" parameterType="long" resultType="User">
-        SELECT * FROM user WHERE id = #{id}
+        SELECT * FROM user WHERE id = #{userId}
     </select>
     <update id="updateUserInfo" parameterType="User" >
         UPDATE user

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -15,4 +15,9 @@
     <select id="selectUserById" parameterType="long" resultType="User">
         SELECT * FROM user WHERE id = #{id}
     </select>
+    <update id="updateUserInfo" parameterType="User" >
+        UPDATE user
+        SET nickname = #{nickname}, profile_img = #{profileImg}
+        WHERE id = #{id}
+    </update>
 </mapper>

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -7,7 +7,7 @@
     <update id="updateUserExp" parameterType="map">
         UPDATE user
         SET exp = exp + #{expPoints}
-        WHERE id = #{userId}
+        WHERE id = #{id}
     </update>
     <select id="selectAllUserIds" resultType="long">
         SELECT id FROM user

--- a/src/test/java/com/him/fpjt/him_backend/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/user/service/UserServiceImplTest.java
@@ -100,4 +100,45 @@ class UserServiceImplTest {
 
         assertThrows(NoSuchElementException.class, () -> userService.getUserById(userId));
     }
+
+    @Test
+    @DisplayName("사용자 정보를 전달할 경우, 사용자의 정보를 수정한다.")
+    void modifyUserInfo_success() {
+        long userId = 1L;
+        User mockUser = new User(userId, "ollie", "email@example.com", "password","profileImg.jpg", Tier.IRON, 2000);
+        UserModifyDto userModifyDto = new UserModifyDto("icarus", "icarus.jpg");
+
+        when(userDao.selectUserById(userId)).thenReturn(mockUser);
+        when(userDao.updateUserInfo(mockUser)).thenReturn(1);
+
+        userService.modifyUserInfo(userId, userModifyDto);
+
+        assertEquals("icarus", mockUser.getNickname());
+        assertEquals("icarus.jpg", mockUser.getProfileImg());
+        verify(userDao).updateUserInfo(mockUser);
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정에 실패할 경우, IllegalStateException이 발생한다.")
+    void modifyUserInfo_illegalStateException() {
+        long userId = 1L;
+        User mockUser = new User(userId, "ollie", "email@example.com", "password","profileImg.jpg", Tier.IRON, 2000);
+        UserModifyDto userModifyDto = new UserModifyDto("newNickname", "newProfileImg.jpg");
+
+        when(userDao.selectUserById(userId)).thenReturn(mockUser);
+        when(userDao.updateUserInfo(mockUser)).thenReturn(0);
+
+        assertThrows(IllegalStateException.class, () -> userService.modifyUserInfo(userId, userModifyDto));
+    }
+
+    @Test
+    @DisplayName("사용자가 존재하지 않는 경우 NoSuchElementException가 발생한다.")
+    void modifyUserInfo_noSuchElementException() {
+        long userId = 1L;
+        UserModifyDto userModifyDto = new UserModifyDto("newNickname", "newProfileImg.jpg");
+
+        when(userDao.selectUserById(userId)).thenReturn(null);
+
+        assertThrows(NoSuchElementException.class, () -> userService.modifyUserInfo(userId, userModifyDto));
+    }
 }

--- a/src/test/java/com/him/fpjt/him_backend/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/user/service/UserServiceImplTest.java
@@ -1,13 +1,21 @@
 package com.him.fpjt.him_backend.user.service;
 
 import com.him.fpjt.him_backend.user.dao.UserDao;
+import com.him.fpjt.him_backend.user.domain.Tier;
+import com.him.fpjt.him_backend.user.domain.User;
+import com.him.fpjt.him_backend.user.dto.UserInfoDto;
+import com.him.fpjt.him_backend.user.dto.UserModifyDto;
+import java.util.NoSuchElementException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -68,5 +76,28 @@ class UserServiceImplTest {
         // When & Then
         assertDoesNotThrow(() -> userService.modifyUserExp(userId, expPoints));
         verify(userDao, times(1)).updateUserExp(userId, expPoints);
+    }
+
+    @Test
+    @DisplayName("사용자 조회 시 사용자 정보를 반환한다.")
+    void getUserById_success() {
+        long userId = 1L;
+        User mockUser = new User(userId, "ollie", "email@example.com", "password","ollie.jpg", Tier.IRON, 2000);
+        when(userDao.selectUserById(userId)).thenReturn(mockUser);
+
+        UserInfoDto userInfo = userService.getUserById(userId);
+
+        assertNotNull(userInfo);
+        assertEquals(userId, userInfo.getId());
+        assertEquals("ollie", userInfo.getNickname());
+        assertEquals("email@example.com", userInfo.getEmail());
+    }
+    @Test
+    @DisplayName("사용자가 존재하지 않는 경우 NoSuchElementException가 발생한다.")
+    void getUserById_noSuchElementException() {
+        long userId = 1L;
+        when(userDao.selectUserById(userId)).thenReturn(null);
+
+        assertThrows(NoSuchElementException.class, () -> userService.getUserById(userId));
     }
 }


### PR DESCRIPTION
## 연관된 이슈

> resolve #39 

## 작업 내용

> 사용자 정보 조회 및 수정 기능을 추가하였습니다.
>- userId를 이용하여 사용자 정보 조회 시 사용자 정보를 반환합니다.
> - 사용자 정보( nickname, profile_img) 를 수정할 수 있습니다.

## 리뷰 요구사항 (선택)
> 사용자 정보 조회와 수정의 경우, 기존 user 도메인에서 일부의 정보만을 조회하거나 업데이트 하기 때문에 user 도메인을 사용하는 것은 불필요한 정보를 노출시킬 수 있다고 생각하여 `userInfoDto`와 `userModifyDto`를 추가하여 기능을 구현하였습니다.