### PR TITLE
닉네임 중복 여부 확인 기능 추가

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/user/controller/AuthController.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/controller/AuthController.java
@@ -1,0 +1,29 @@
+package com.him.fpjt.him_backend.user.controller;
+
+import com.him.fpjt.him_backend.user.service.AuthService;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+@Validated
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @GetMapping("/check")
+    public ResponseEntity<?> checkDuplicateNickname(@NotBlank @RequestParam("nickname") String nickname) {
+        boolean isDuplicated = authService.checkDuplicatedNickname(nickname);
+        if (isDuplicated) {
+            return ResponseEntity.ok().body("이미 사용 중인 닉네임입니다.");
+        }
+        return ResponseEntity.ok().body("사용 가능한 닉네임입니다.");
+    }
+}

--- a/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
@@ -7,3 +7,4 @@ public interface UserDao {
     int updateUserExp(long userId, long expPoints);
     List<Long> selectAllUserIds();
 }
+    boolean existsDuplicatedNickname(String nickname);

--- a/src/main/java/com/him/fpjt/him_backend/user/service/AuthService.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/AuthService.java
@@ -1,0 +1,5 @@
+package com.him.fpjt.him_backend.user.service;
+
+public interface AuthService {
+     boolean checkDuplicatedNickname(String nickname);
+}

--- a/src/main/java/com/him/fpjt/him_backend/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/AuthServiceImpl.java
@@ -1,0 +1,20 @@
+package com.him.fpjt.him_backend.user.service;
+
+import com.him.fpjt.him_backend.user.dao.UserDao;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class AuthServiceImpl implements AuthService {
+    private final UserDao userDao;
+
+    public AuthServiceImpl(UserDao userDao) {
+        this.userDao = userDao;
+    }
+
+    @Override
+    public boolean checkDuplicatedNickname(String nickname) {
+        return userDao.existsDuplicatedNickname(nickname);
+    }
+}

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -12,4 +12,9 @@
     <select id="selectAllUserIds" resultType="long">
         SELECT id FROM user
     </select>
+    <select id="existsDuplicatedNickname" parameterType="String" resultType="boolean">
+        SELECT COUNT(1) > 0
+        FROM user
+        WHERE nickname = #{nickname}
+    </select>
 </mapper>

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/AuthServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/AuthServiceImplTest.java
@@ -1,0 +1,50 @@
+package com.him.fpjt.him_backend.exercise.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.him.fpjt.him_backend.user.dao.UserDao;
+import com.him.fpjt.him_backend.user.service.AuthServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class AuthServiceImplTest {
+    @Mock
+    private UserDao userDao;
+
+    @InjectMocks
+    private AuthServiceImpl authService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 닉네임은 true를 반환합니다.")
+    void checkDuplicatedNickname_duplicated() {
+        String nickname = "ollie";
+        when(userDao.existsDuplicatedNickname(nickname)).thenReturn(true);
+
+        boolean isDuplicated = authService.checkDuplicatedNickname(nickname);
+
+        assertTrue(isDuplicated);
+    }
+
+    @Test
+    @DisplayName("이전에 없던 닉네임은 false를 반환합니다.")
+    void checkDuplicatedNickname_unique() {
+        String nickname = "ollie";
+        when(userDao.existsDuplicatedNickname(nickname)).thenReturn(false);
+
+        boolean isDuplicated = authService.checkDuplicatedNickname(nickname);
+
+        assertFalse(isDuplicated);
+    }
+
+}


### PR DESCRIPTION
## 연관된 이슈

> 

## 작업 내용

> 닉네임 중복 여부 확인 기능을 구현하였습니다.

## 리뷰 요구사항 (선택)
> 현재 `@NotBlank` 어노테이션을 사용하여 닉네임이 비어있는 경우 `ConstraintViolationException` 예외가 발생하도록 처리했습니다. 이 예외는 Spring에서 `@NotBlank` 검증 후 즉시 발생하는 에러로, 추후 공통 에러 처리 모듈에서 해당 부분을 일괄적으로 처리할 수 있도록 구현할 예정입니다.
