### PR TITLE
게임 : FE BE api 연동

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
@@ -25,10 +25,10 @@ public class GameController {
     }
 
     @PutMapping
-    public ResponseEntity<String> achieveGame(@RequestBody GameDto gameDto) {
+    public ResponseEntity<Object> achieveGame(@RequestBody GameDto gameDto) {
         if (gameDto.isAchieved()) {
-            gameService.applyUserExp(gameDto.getGameId());
-            return ResponseEntity.ok("조건에 따른 경험치 반영이 완료되었습니다.");
+            long expPoints = gameService.applyUserExp(gameDto.getGameId());
+            return ResponseEntity.ok(expPoints);
         } else {
             return ResponseEntity.ok("성취하지 않은 상태이므로 경험치가 반영되지 않았습니다.");
         }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/game")
+@CrossOrigin("*")
 public class GameController {
 
     private final GameService gameService;
@@ -18,9 +19,9 @@ public class GameController {
     }
 
     @PostMapping
-    public ResponseEntity<String> createGame(@RequestBody Game game) {
-        gameService.createGame(game);
-        return ResponseEntity.ok("게임이 성공적으로 추가되었습니다.");
+    public ResponseEntity<Long> createGame(@RequestBody Game game) {
+        long gameId = gameService.createGame(game);
+        return ResponseEntity.ok(gameId);
     }
 
     @PutMapping

--- a/src/main/java/com/him/fpjt/him_backend/exercise/domain/Game.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/domain/Game.java
@@ -1,16 +1,17 @@
 package com.him.fpjt.him_backend.exercise.domain;
 
 import java.time.LocalDate;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.ToString;
+
+import lombok.*;
 
 @Getter
 @ToString
 @AllArgsConstructor
+@NoArgsConstructor
+@Setter
 public class Game {
     private long id;
-    private LocalDate date;
+    private LocalDate date = LocalDate.now();
     private ExerciseType type;
     private DifficultyLevel difficultyLevel;
     private boolean isAchieved;

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dto/GameDto.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dto/GameDto.java
@@ -1,17 +1,25 @@
 package com.him.fpjt.him_backend.exercise.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
 
 @Getter
 @Setter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @AllArgsConstructor
 @NoArgsConstructor
+@ToString
 public class GameDto {
     private long gameId;
+
+    // Lombok의 @Getter, @Setter 어노테이션은 Java 객체 필드에 대해 getter와 setter 메서드를 자동으로 생성
+    // 하지만, boolean 타입의 필드의 경우, getter 메서드의 이름이 Jackson의 기본 작명 규칙과 충돌할 수 있다.
+    // 예를 들어,
+    // Lombok -> isIsAchieved() 라는 getter 메서드를 생성
+    // Jackson -> isAchieved() 라는 메서드를 기대
+    // => 올바른 역직렬화 불가
+    // => @JsonProperty("isAchieved")을 통해 프론트단에서 Json으로 넘어오는 데이터를 isAchieved로 받겠다고 선언
+    @JsonProperty("isAchieved")
     private boolean isAchieved;
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameService.java
@@ -4,7 +4,7 @@ import com.him.fpjt.him_backend.exercise.domain.Game;
 
 public interface GameService {
 
-    void createGame(Game game);
+    long createGame(Game game);
 
     void applyUserExp(long gameId);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameService.java
@@ -6,5 +6,5 @@ public interface GameService {
 
     long createGame(Game game);
 
-    void applyUserExp(long gameId);
+    long applyUserExp(long gameId);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
@@ -23,11 +23,12 @@ public class GameServiceImpl implements GameService {
 
     @Override
     @Transactional
-    public void createGame(Game game) {
+    public long createGame(Game game) {
         int result = gameDao.insertGame(game);
         if (result == 0) {
             throw new IllegalStateException("게임 생성에 실패했습니다.");
         }
+        return game.getId();
     }
 
     @Override

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
@@ -33,16 +33,20 @@ public class GameServiceImpl implements GameService {
 
     @Override
     @Transactional
-    public void applyUserExp(long gameId) {
+    public long applyUserExp(long gameId) {
         Game currentGame = validateGameExists(gameId);
+
         long userId = currentGame.getUserId();
 
+        long expPoints = 0L;
         if (!checkForSimilarAchievements(currentGame, userId)) {
-            long expPoints = calculateExpPoints(currentGame.getDifficultyLevel());
+            expPoints = calculateExpPoints(currentGame.getDifficultyLevel());
             updateUserExperience(userId, expPoints);
         }
 
         updateGameAchievementStatus(gameId);
+
+        return expPoints;
     }
 
     private Game validateGameExists(long gameId) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,7 @@ mybatis:
   type-aliases-package: com.him.fpjt.him_backend.exercise.domain, com.him.fpjt.him_backend.user.domain, com.him.fpjt.him_backend.auth.domain
   configuration:
     log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
+    map-underscore-to-camel-case: true
 ---
 spring:
   config:

--- a/src/main/resources/mappers/GameMapper.xml
+++ b/src/main/resources/mappers/GameMapper.xml
@@ -5,7 +5,7 @@
 <mapper namespace="com.him.fpjt.him_backend.exercise.dao.GameDao">
 
     <!-- 새로운 게임을 삽입하는 SQL 구문 -->
-    <insert id="insertGame" parameterType="Game">
+    <insert id="insertGame" parameterType="Game" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO game (date, type, difficulty_level, is_achieved, user_id)
         VALUES (#{date}, #{type}, #{difficultyLevel}, false, #{userId})
     </insert>

--- a/src/main/resources/mappers/GameMapper.xml
+++ b/src/main/resources/mappers/GameMapper.xml
@@ -4,18 +4,15 @@
 
 <mapper namespace="com.him.fpjt.him_backend.exercise.dao.GameDao">
 
-    <!-- 새로운 게임을 삽입하는 SQL 구문 -->
     <insert id="insertGame" parameterType="Game" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO game (date, type, difficulty_level, is_achieved, user_id)
         VALUES (#{date}, #{type}, #{difficultyLevel}, false, #{userId})
     </insert>
 
-    <!-- 특정 게임 ID로 게임 정보 조회 (userId 포함) -->
     <select id="findGameById" parameterType="long" resultType="Game">
         SELECT * FROM game WHERE id = #{gameId}
     </select>
 
-    <!-- 동일 날짜, 동일 유형, 동일 난이도에서 성공 처리된 게임이 있는지 확인 -->
     <select id="existsAchievedGame" parameterType="map" resultType="boolean">
         SELECT EXISTS (
             SELECT 1 FROM game
@@ -27,7 +24,6 @@
         )
     </select>
 
-    <!-- 특정 게임 ID로 성공 여부를 true로 수정하는 SQL 구문 -->
     <update id="updateGameAchievement" parameterType="long">
         UPDATE game
         SET is_achieved = true


### PR DESCRIPTION
## 연관된 이슈

> #50 

## 작업 내용

- FE에서 게임 선택 (운동 타입과 난이도)에 대한 정보를 BE에서 받아 게임을 생성하는 연동 기능을 구현하였습니다.
- BE단에서 생성된 gameId을 반환하여 FE에서 사용가능하도록 연동하였습니다.
- FE에서 게임이 성공했을 때, 이에 대한 정보를 BE에서 받아 사용자의 경험치와 게임의 성공 여부를 업데이트하는 연동 기능을 구현하였습니다.
- 게임 경험치의 경우, 프론트에서도 관리할 수도 있지만 효율적인 유지 보수를 위해 백단에서 업데이트된 경험치 값을 반환하여 프론트에서도 사용가능하도록 구현하였습니다.
- CORS 에러를 막기 위해, 임시로 Controller에 CrossOrigin("*")을 추가하였습니다.
- GameDto의 경우, 사용자 경험치 및 게임 성공 여부를 업데이트하기 위해 사용하는 DTO인데, Lombok과 Jackson의 작명 규칙이 상이함에 따라, 발생하는 문제를 JsonProperty을 통해 해결하였습니다.
   - 문제점에 대한 정보를 공유하기 위해 주석으로 남겨두었습니다.
- mapper에서 카멜케이스와 스네이크케이스의 변환을 다루기 위해 application.yml에 관련 기능을 추가하였습니다.

### 스크린샷 (선택)

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 또한 게임 레코드를 추가하는 과정에서 Jackson이 기본 생성자를 요구함에 따라 Game 도메인에 기본 생성자를 추가하였습니다. DTO로 변경하는 것이 좋을지 여쭙고 싶습니다.
