### PR TITLE
todayChallenge CORS 추가 및 조회 파라미터 변경

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
@@ -4,6 +4,7 @@ import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import com.him.fpjt.him_backend.exercise.dto.TodayChallengeDto;
 import com.him.fpjt.him_backend.exercise.service.TodayChallengeService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/today-challenge")
+@CrossOrigin(origins = "http://localhost:5173")
 public class TodayChallengeController {
     private TodayChallengeService todayChallengeService;
 

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
@@ -3,13 +3,14 @@ package com.him.fpjt.him_backend.exercise.controller;
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import com.him.fpjt.him_backend.exercise.dto.TodayChallengeDto;
 import com.him.fpjt.him_backend.exercise.service.TodayChallengeService;
+import java.time.LocalDate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,9 +22,11 @@ public class TodayChallengeController {
     public TodayChallengeController(TodayChallengeService todayChallengeService) {
         this.todayChallengeService = todayChallengeService;
     }
-    @GetMapping("{todayChallengeId}")
-    public ResponseEntity<Object> getTodayChallenge(@PathVariable("todayChallengeId") long id) {
-        TodayChallenge todayChallenge = todayChallengeService.getTodayChallengeById(id);
+    @GetMapping
+    public ResponseEntity<Object> getTodayChallenge(@RequestParam(value = "challengeId") long challengeId,
+            @RequestParam(value = "date") LocalDate date) {
+        TodayChallenge todayChallenge = todayChallengeService.getTodayChallengeByChallengeIdAndDate(challengeId, date);
+        System.out.println(todayChallenge.toString());
         return ResponseEntity.ok().body(todayChallenge);
     }
     @PutMapping

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
@@ -7,6 +7,7 @@ import java.util.List;
 public interface TodayChallengeDao {
     public long insertTodayChallenge(TodayChallenge todayChallenge);
     public TodayChallenge selectTodayChallengeById(long id);
+    public TodayChallenge selectTodayChallengeByChallengeIdAndDate(long challengeId, LocalDate date);
     public long updateTodayChallenge(TodayChallenge todayChallenge);
     public boolean checkAchievementBonus(long challengeId, LocalDate date, int days);
     public List<TodayChallenge> findUnachievedChallenges(LocalDate yesterday);

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeService.java
@@ -2,10 +2,12 @@ package com.him.fpjt.him_backend.exercise.service;
 
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import com.him.fpjt.him_backend.exercise.dto.TodayChallengeDto;
+import java.time.LocalDate;
 
 public interface TodayChallengeService {
     public void createTodayChallenge();
     public TodayChallenge getTodayChallengeById(long id);
+    public TodayChallenge getTodayChallengeByChallengeIdAndDate(long challengeId, LocalDate date);
     public boolean modifyTodayChallenge(TodayChallengeDto todayChallengeDto);
     public void modifyUnachievementTodayChallenge() throws Exception;
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
@@ -46,6 +46,12 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
                 .orElseThrow(() -> new NoSuchElementException("해당 ID의 오늘의 챌린지가 존재하지 않습니다."));
     }
 
+    @Override
+    public TodayChallenge getTodayChallengeByChallengeIdAndDate(long challengeId, LocalDate date) {
+        return Optional.ofNullable(todayChallengeDao.selectTodayChallengeByChallengeIdAndDate(challengeId, date))
+                .orElseThrow(() -> new NoSuchElementException("해당 ID의 오늘의 챌린지가 존재하지 않습니다."));
+    }
+
     @Transactional
     @Override
     public boolean modifyTodayChallenge(TodayChallengeDto newTodayChallengeDto){

--- a/src/main/resources/HIM_schema.sql
+++ b/src/main/resources/HIM_schema.sql
@@ -61,14 +61,15 @@ CREATE TABLE `today_challenge`(
     `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
     `cnt` BIGINT NOT NULL,
     `challenge_id` BIGINT UNSIGNED NOT NULL,
+    `date` DATE NOT NULL,
     CONSTRAINT `today_challenge_challenge_id_foreign` FOREIGN KEY (`challenge_id`) REFERENCES `challenge` (`id`)
 );
 -- today_challenge 객체에 목업 데이터 삽입
-INSERT INTO `today_challenge` (`cnt`, `challenge_id`)
+INSERT INTO `today_challenge` (`cnt`, `challenge_id`, `date`)
 VALUES 
-    (15, 1),
-    (10, 2),
-    (21, 3);
+    (15, 1, '2024-11-18'),
+    (10, 2, '2024-04-02'),
+    (21, 3, '2024-04-03');
 SELECT * FROM today_challenge;
 
 CREATE TABLE `attendance`(

--- a/src/main/resources/mappers/TodayChallengeMapper.xml
+++ b/src/main/resources/mappers/TodayChallengeMapper.xml
@@ -9,6 +9,9 @@
   <select id="selectTodayChallengeById" parameterType="long" resultType="TodayChallenge">
     SELECT * FROM today_challenge WHERE id = #{id}
   </select>
+  <select id="selectTodayChallengeByChallengeIdAndDate" parameterType="map" resultType="TodayChallenge">
+    SELECT * FROM today_challenge WHERE challenge_id = #{challengeId} and date = #{date}
+  </select>
   <update id="updateTodayChallenge" parameterType="TodayChallenge">
     UPDATE today_challenge SET cnt = #{cnt} WHERE id = #{id}
   </update>


### PR DESCRIPTION
## 연관된 이슈

> 

## 작업 내용

> todayChallenge api 파트 연동 작업을 하면서 코드를 수정하였습니다.
> - todayChallengeController CORS 설정 추가하였습니다.
> - todayChallenge 조회 API의 경우 todayChallengeId를 이용해 조회하는 방식에서 challengeId와 date를 이용하여 조회하는 방식으로 수정하였습니다.
> - todayChallenge 스키마에 date 필드를 추가하였습니다.

