### PR TITLE
user와 todayChallenge, game 연동에 따른 game, todayChallenge 조회 API 추가

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
@@ -4,6 +4,7 @@ import com.him.fpjt.him_backend.exercise.domain.Game;
 import com.him.fpjt.him_backend.exercise.dto.GameDto;
 import com.him.fpjt.him_backend.exercise.service.GameService;
 import com.him.fpjt.him_backend.user.service.UserService;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,5 +33,13 @@ public class GameController {
         } else {
             return ResponseEntity.ok("성취하지 않은 상태이므로 경험치가 반영되지 않았습니다.");
         }
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<?> getMonthlyGame(@PathVariable("userId") long userId,
+                                            @RequestParam("year") int year,
+                                            @RequestParam("month") int month) {
+        List<Game> games = gameService.getMonthlyGame(userId, year, month);
+        return ResponseEntity.ok().body(games);
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/GameController.java
@@ -4,6 +4,7 @@ import com.him.fpjt.him_backend.exercise.domain.Game;
 import com.him.fpjt.him_backend.exercise.dto.GameDto;
 import com.him.fpjt.him_backend.exercise.service.GameService;
 import com.him.fpjt.him_backend.user.service.UserService;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -40,6 +41,11 @@ public class GameController {
                                             @RequestParam("year") int year,
                                             @RequestParam("month") int month) {
         List<Game> games = gameService.getMonthlyGame(userId, year, month);
+        return ResponseEntity.ok().body(games);
+    }
+    @GetMapping("/list")
+    public ResponseEntity<Object> getGames(@RequestParam(value = "userId") long userId, @RequestParam(value = "date") LocalDate date) {
+        List<Game> games = gameService.getGameByUserIdAndDate(userId, date);
         return ResponseEntity.ok().body(games);
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
@@ -30,6 +30,12 @@ public class TodayChallengeController {
         TodayChallenge todayChallenge = todayChallengeService.getTodayChallengeByChallengeIdAndDate(challengeId, date);
         return ResponseEntity.ok().body(todayChallenge);
     }
+
+    @GetMapping("/list")
+    public ResponseEntity<Object> getTodayChallenges(@RequestParam(value = "userId") long userId, @RequestParam(value = "date") LocalDate date) {
+        List<TodayChallenge> todayChallenges = todayChallengeService.getTodayChallengeByUserIdAndDate(userId, date);
+        return ResponseEntity.ok().body(todayChallenges);
+    }
     @PutMapping
     public ResponseEntity<Object> modifyTodayChallenge(@RequestBody TodayChallengeDto todayChallengeDto) {
         todayChallengeService.modifyTodayChallenge(todayChallengeDto);

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
@@ -41,7 +41,6 @@ public class TodayChallengeController {
             @RequestParam("year") int year,
             @RequestParam("month") int month) {
         List<TodayChallenge> todayChallenges = todayChallengeService.getMonthlyTodayChallenge(userId, year, month);
-        System.out.println(todayChallenges.toString());
         return ResponseEntity.ok().body(todayChallenges);
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
@@ -26,7 +26,6 @@ public class TodayChallengeController {
     public ResponseEntity<Object> getTodayChallenge(@RequestParam(value = "challengeId") long challengeId,
             @RequestParam(value = "date") LocalDate date) {
         TodayChallenge todayChallenge = todayChallengeService.getTodayChallengeByChallengeIdAndDate(challengeId, date);
-        System.out.println(todayChallenge.toString());
         return ResponseEntity.ok().body(todayChallenge);
     }
     @PutMapping

--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
@@ -4,9 +4,11 @@ import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import com.him.fpjt.him_backend.exercise.dto.TodayChallengeDto;
 import com.him.fpjt.him_backend.exercise.service.TodayChallengeService;
 import java.time.LocalDate;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,5 +34,14 @@ public class TodayChallengeController {
     public ResponseEntity<Object> modifyTodayChallenge(@RequestBody TodayChallengeDto todayChallengeDto) {
         todayChallengeService.modifyTodayChallenge(todayChallengeDto);
         return ResponseEntity.ok("오늘의 챌린지가 성공적으로 수정되었습니다.");
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<?> getMonthlyTodayChallenge(@PathVariable("userId") long userId,
+            @RequestParam("year") int year,
+            @RequestParam("month") int month) {
+        List<TodayChallenge> todayChallenges = todayChallengeService.getMonthlyTodayChallenge(userId, year, month);
+        System.out.println(todayChallenges.toString());
+        return ResponseEntity.ok().body(todayChallenges);
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/GameDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/GameDao.java
@@ -2,6 +2,7 @@ package com.him.fpjt.him_backend.exercise.dao;
 
 import com.him.fpjt.him_backend.exercise.domain.Game;
 
+import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -15,4 +16,5 @@ public interface GameDao {
 
     int updateGameAchievement(long id);
     List<Game> selectGameByUserIdAndDateRange(long userId, LocalDate startOfMonth, LocalDate endOfMonth);
+    List<Game> selectGameByUserIdAndDate(long userId, LocalDate date);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/GameDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/GameDao.java
@@ -1,9 +1,9 @@
 package com.him.fpjt.him_backend.exercise.dao;
 
 import com.him.fpjt.him_backend.exercise.domain.Game;
-import com.him.fpjt.him_backend.exercise.dto.GameDto;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface GameDao {
 
@@ -14,4 +14,5 @@ public interface GameDao {
     boolean existsAchievedGame(LocalDate date, String type, String difficultyLevel, long userId);
 
     int updateGameAchievement(long id);
+    List<Game> selectGameByUserIdAndDateRange(long userId, LocalDate startOfMonth, LocalDate endOfMonth);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
@@ -11,5 +11,6 @@ public interface TodayChallengeDao {
     public long updateTodayChallenge(TodayChallenge todayChallenge);
     public boolean checkAchievementBonus(long challengeId, LocalDate date, int days);
     public List<TodayChallenge> findUnachievedChallenges(LocalDate yesterday);
+    public List<TodayChallenge> selectTodayChallengeByUserIdAndDateRange(long userId, LocalDate startOfMonth, LocalDate endOfMonth);
     public long updateIsAchieved(long id);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
@@ -8,6 +8,7 @@ public interface TodayChallengeDao {
     public long insertTodayChallenge(TodayChallenge todayChallenge);
     public TodayChallenge selectTodayChallengeById(long id);
     public TodayChallenge selectTodayChallengeByChallengeIdAndDate(long challengeId, LocalDate date);
+    public List<TodayChallenge> selectTodayChallengeByUserIdAndDate(long userId, LocalDate date);
     public long updateTodayChallenge(TodayChallenge todayChallenge);
     public boolean checkAchievementBonus(long challengeId, LocalDate date, int days);
     public List<TodayChallenge> findUnachievedChallenges(LocalDate yesterday);

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/TodayChallengeDao.java
@@ -11,4 +11,5 @@ public interface TodayChallengeDao {
     public long updateTodayChallenge(TodayChallenge todayChallenge);
     public boolean checkAchievementBonus(long challengeId, LocalDate date, int days);
     public List<TodayChallenge> findUnachievedChallenges(LocalDate yesterday);
+    public long updateIsAchieved(long id);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/domain/TodayChallenge.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/domain/TodayChallenge.java
@@ -15,11 +15,19 @@ public class TodayChallenge {
     private long cnt;
     private long challengeId;
     private LocalDate date;
+    private boolean isAchieved;
 
     public TodayChallenge(long cnt, long challengeId, LocalDate date) {
         this.cnt = cnt;
         this.challengeId = challengeId;
         this.date = date;
+    }
+
+    public TodayChallenge(long cnt, long challengeId, LocalDate date, boolean isAchieved) {
+        this.cnt = cnt;
+        this.challengeId = challengeId;
+        this.date = date;
+        this.isAchieved = isAchieved;
     }
 
     public void setCnt(long cnt) {

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameService.java
@@ -1,10 +1,12 @@
 package com.him.fpjt.him_backend.exercise.service;
 
 import com.him.fpjt.him_backend.exercise.domain.Game;
+import java.util.List;
 
 public interface GameService {
 
     long createGame(Game game);
 
     long applyUserExp(long gameId);
+    List<Game> getMonthlyGame(long userId, int year, int month);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameService.java
@@ -1,12 +1,13 @@
 package com.him.fpjt.him_backend.exercise.service;
 
 import com.him.fpjt.him_backend.exercise.domain.Game;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface GameService {
 
     long createGame(Game game);
-
     long applyUserExp(long gameId);
     List<Game> getMonthlyGame(long userId, int year, int month);
+    List<Game> getGameByUserIdAndDate(long userId, LocalDate date);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
@@ -5,6 +5,8 @@ import com.him.fpjt.him_backend.exercise.dao.GameDao;
 import com.him.fpjt.him_backend.exercise.domain.DifficultyLevel;
 import com.him.fpjt.him_backend.exercise.domain.Game;
 import com.him.fpjt.him_backend.user.dao.UserDao;
+import java.time.YearMonth;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -85,5 +87,16 @@ public class GameServiceImpl implements GameService {
             case MEDIUM -> ExpPoints.GAME_MEDIUM_MODE;
             case HARD -> ExpPoints.GAME_HARD_MODE;
         };
+    }
+
+    @Override
+    public List<Game> getMonthlyGame(long userId, int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        List<Game> games = gameDao.selectGameByUserIdAndDateRange(userId, yearMonth.atDay(1),
+                yearMonth.atEndOfMonth());
+        if (games == null || games.isEmpty()) {
+            throw new NoSuchElementException("해당 회원의 게임 기록이 존재하지 않습니다.");
+        }
+        return games;
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/GameServiceImpl.java
@@ -5,8 +5,10 @@ import com.him.fpjt.him_backend.exercise.dao.GameDao;
 import com.him.fpjt.him_backend.exercise.domain.DifficultyLevel;
 import com.him.fpjt.him_backend.exercise.domain.Game;
 import com.him.fpjt.him_backend.user.dao.UserDao;
+import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -98,5 +100,11 @@ public class GameServiceImpl implements GameService {
             throw new NoSuchElementException("해당 회원의 게임 기록이 존재하지 않습니다.");
         }
         return games;
+    }
+
+    @Override
+    public List<Game> getGameByUserIdAndDate(long userId, LocalDate date) {
+        return Optional.ofNullable(gameDao.selectGameByUserIdAndDate(userId, date))
+                .orElseThrow(() -> new NoSuchElementException("해당 ID의 오늘의 챌린지가 존재하지 않습니다."));
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeService.java
@@ -9,6 +9,7 @@ public interface TodayChallengeService {
     public void createTodayChallenge();
     public TodayChallenge getTodayChallengeById(long id);
     public TodayChallenge getTodayChallengeByChallengeIdAndDate(long challengeId, LocalDate date);
+    public List<TodayChallenge> getTodayChallengeByUserIdAndDate(long userId, LocalDate date);
     public boolean modifyTodayChallenge(TodayChallengeDto todayChallengeDto);
     public void modifyUnachievementTodayChallenge() throws Exception;
     List<TodayChallenge> getMonthlyTodayChallenge(long userId, int year, int month);

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeService.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeService.java
@@ -3,6 +3,7 @@ package com.him.fpjt.him_backend.exercise.service;
 import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import com.him.fpjt.him_backend.exercise.dto.TodayChallengeDto;
 import java.time.LocalDate;
+import java.util.List;
 
 public interface TodayChallengeService {
     public void createTodayChallenge();
@@ -10,4 +11,5 @@ public interface TodayChallengeService {
     public TodayChallenge getTodayChallengeByChallengeIdAndDate(long challengeId, LocalDate date);
     public boolean modifyTodayChallenge(TodayChallengeDto todayChallengeDto);
     public void modifyUnachievementTodayChallenge() throws Exception;
+    List<TodayChallenge> getMonthlyTodayChallenge(long userId, int year, int month);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
@@ -34,7 +34,7 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
     public void createTodayChallenge() {
         List<Long> allChallengeId = challengeService.getAllChallengeId();
         for (Long challengeId : allChallengeId) {
-            long todayChallengeId = todayChallengeDao.insertTodayChallenge(new TodayChallenge(0, challengeId, LocalDate.now()));
+            long todayChallengeId = todayChallengeDao.insertTodayChallenge(new TodayChallenge(0, challengeId, LocalDate.now(), false));
             if (todayChallengeId <= 0) {
                 throw new IllegalStateException("챌린지 생성에 실패했습니다.");
             }
@@ -65,6 +65,7 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
             challengeService.modifyChallengeAchieveCnt(todayChallenge.getChallengeId());
 
             addAchievementExp(todayChallenge, challenge);
+            todayChallengeDao.updateIsAchieved(todayChallenge.getId());
         }
         return isUpdated;
     }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
@@ -7,6 +7,7 @@ import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import com.him.fpjt.him_backend.exercise.dto.TodayChallengeDto;
 import com.him.fpjt.him_backend.user.service.UserService;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -102,5 +103,16 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
         for (TodayChallenge unachievedTodayChallenge : unachievedTodayChallenges) {
             userService.modifyUserExp(challengeService.getChallengeDetail(unachievedTodayChallenge.getChallengeId()).getUserId(), ExpPoints.DAILY_PENALTY_EXP);
         }
+    }
+
+    @Override
+    public List<TodayChallenge> getMonthlyTodayChallenge(long userId, int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        List<TodayChallenge> todayChallenges = todayChallengeDao.selectTodayChallengeByUserIdAndDateRange(
+                userId, yearMonth.atDay(1), yearMonth.atEndOfMonth());
+        if (todayChallenges == null || todayChallenges.isEmpty()) {
+            throw new NoSuchElementException("해당 회원의 오늘의 챌린지 기록이 존재하지 않습니다.");
+        }
+        return todayChallenges;
     }
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
@@ -53,6 +53,12 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
                 .orElseThrow(() -> new NoSuchElementException("해당 ID의 오늘의 챌린지가 존재하지 않습니다."));
     }
 
+    @Override
+    public List<TodayChallenge> getTodayChallengeByUserIdAndDate(long userId, LocalDate date) {
+        return Optional.ofNullable(todayChallengeDao.selectTodayChallengeByUserIdAndDate(userId, date))
+                .orElseThrow(() -> new NoSuchElementException("해당 ID의 오늘의 챌린지가 존재하지 않습니다."));
+    }
+
     @Transactional
     @Override
     public boolean modifyTodayChallenge(TodayChallengeDto newTodayChallengeDto){

--- a/src/main/java/com/him/fpjt/him_backend/user/controller/AttendanceController.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/controller/AttendanceController.java
@@ -4,8 +4,6 @@ import com.him.fpjt.him_backend.user.domain.Attendance;
 import com.him.fpjt.him_backend.user.service.AttendenceService;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.NoSuchElementException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/him/fpjt/him_backend/user/controller/AttendanceController.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/controller/AttendanceController.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/attendance")
+@CrossOrigin(origins = "http://localhost:5173")
 public class AttendanceController {
     private AttendenceService attendenceService;
 

--- a/src/main/java/com/him/fpjt/him_backend/user/controller/UserController.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.him.fpjt.him_backend.user.dto.UserInfoDto;
 import com.him.fpjt.him_backend.user.dto.UserModifyDto;
 import com.him.fpjt.him_backend.user.service.UserService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/user")
+@CrossOrigin(origins = "http://localhost:5173")
 public class UserController {
     private UserService userService;
 

--- a/src/main/resources/HIM_schema.sql
+++ b/src/main/resources/HIM_schema.sql
@@ -62,14 +62,15 @@ CREATE TABLE `today_challenge`(
     `cnt` BIGINT NOT NULL,
     `challenge_id` BIGINT UNSIGNED NOT NULL,
     `date` DATE NOT NULL,
+    `is_achieved` BOOLEAN NOT NULL,
     CONSTRAINT `today_challenge_challenge_id_foreign` FOREIGN KEY (`challenge_id`) REFERENCES `challenge` (`id`)
 );
 -- today_challenge 객체에 목업 데이터 삽입
-INSERT INTO `today_challenge` (`cnt`, `challenge_id`, `date`)
+INSERT INTO `today_challenge` (`cnt`, `challenge_id`, `date`, `is_achieved`)
 VALUES 
-    (15, 1, '2024-11-18'),
-    (10, 2, '2024-04-02'),
-    (21, 3, '2024-04-03');
+    (15, 1, '2024-09-19', true),
+    (10, 2, '2024-09-02', true),
+    (21, 3, '2024-09-03', false);
 SELECT * FROM today_challenge;
 
 CREATE TABLE `attendance`(

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -3,7 +3,7 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.him.fpjt.him_backend.exercise.dao.ChallengeDao">
   <insert id="insertChallenge" parameterType="Challenge">
-    INSERT INTO challenge (title, status, type, start_dt, end_dt, goal_cnt, achieve_cnt, user_id)
+    INSERT INTO challenge (title, status, type, start_dt, end_dt, goal_cnt, achieved_cnt, user_id)
         VALUES (#{title}, #{status}, #{type}, #{startDt}, #{endDt}, #{goalCnt}, #{achievedCnt}, #{userId})
   </insert>
   <select id="selectChallengesByStatusAndUserId" parameterType="map" resultType="Challenge">
@@ -32,7 +32,7 @@
     )
   </select>
   <update id="updateChallengeAchieveCnt" parameterType="long">
-    UPDATE challenge SET achieve_cnt = achieve_cnt + 1 WHERE id = #{id}
+    UPDATE challenge SET achieved_cnt = achieved_cnt + 1 WHERE id = #{id}
   </update>
   <select id="existsChallengeByStartDate" parameterType="java.time.LocalDate" resultType="boolean">
     SELECT EXISTS (

--- a/src/main/resources/mappers/GameMapper.xml
+++ b/src/main/resources/mappers/GameMapper.xml
@@ -29,4 +29,9 @@
         SET is_achieved = true
         WHERE id = #{id}
     </update>
+    <select id="selectGameByUserIdAndDateRange" parameterType="map" resultType="Game">
+        SELECT * FROM game
+        WHERE user_id = #{userId}
+          AND date BETWEEN #{startOfMonth} AND #{endOfMonth}
+    </select>
 </mapper>

--- a/src/main/resources/mappers/GameMapper.xml
+++ b/src/main/resources/mappers/GameMapper.xml
@@ -34,4 +34,9 @@
         WHERE user_id = #{userId}
           AND date BETWEEN #{startOfMonth} AND #{endOfMonth}
     </select>
+    <select id="selectGameByUserIdAndDate" parameterType="map" resultType="Game">
+        SELECT * FROM game
+        WHERE user_id = #{userId}
+          AND date = #{date}
+    </select>
 </mapper>

--- a/src/main/resources/mappers/TodayChallengeMapper.xml
+++ b/src/main/resources/mappers/TodayChallengeMapper.xml
@@ -30,6 +30,13 @@
       AND c.status = 'ONGOING'
       AND tc.cnt &lt; c.goal_cnt
   </select>
+  <select id="selectTodayChallengeByUserIdAndDateRange" parameterType="map" resultType="TodayChallenge">
+      SELECT tc.*
+      FROM today_challenge tc
+             JOIN challenge c ON tc.challenge_id = c.id
+      WHERE c.user_id = #{userId}
+        AND tc.date BETWEEN #{startOfMonth} AND #{endOfMonth}
+  </select>
   <update id="updateIsAchieved" parameterType="long">
     UPDATE today_challenge SET is_achieved = true WHERE id = #{id}
   </update>

--- a/src/main/resources/mappers/TodayChallengeMapper.xml
+++ b/src/main/resources/mappers/TodayChallengeMapper.xml
@@ -12,6 +12,13 @@
   <select id="selectTodayChallengeByChallengeIdAndDate" parameterType="map" resultType="TodayChallenge">
     SELECT * FROM today_challenge WHERE challenge_id = #{challengeId} and date = #{date}
   </select>
+  <select id="selectTodayChallengeByUserIdAndDate" parameterType="map" resultType="TodayChallenge">
+    SELECT tc.*
+    FROM today_challenge tc
+           JOIN challenge c ON tc.challenge_id = c.id
+    WHERE c.user_id = #{userId}
+      AND tc.date = #{date}
+  </select>
   <update id="updateTodayChallenge" parameterType="TodayChallenge">
     UPDATE today_challenge SET cnt = #{cnt} WHERE id = #{id}
   </update>

--- a/src/main/resources/mappers/TodayChallengeMapper.xml
+++ b/src/main/resources/mappers/TodayChallengeMapper.xml
@@ -3,8 +3,8 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.him.fpjt.him_backend.exercise.dao.TodayChallengeDao">
   <insert id="insertTodayChallenge" parameterType="TodayChallenge" useGeneratedKeys="true" keyProperty="id">
-    INSERT INTO today_challenge (cnt, challenge_id, date)
-    VALUES (#{cnt}, #{challengeId}, #{date})
+    INSERT INTO today_challenge (cnt, challenge_id, date, is_achieved)
+    VALUES (#{cnt}, #{challengeId}, #{date}, #{isAchieved})
   </insert>
   <select id="selectTodayChallengeById" parameterType="long" resultType="TodayChallenge">
     SELECT * FROM today_challenge WHERE id = #{id}
@@ -30,4 +30,7 @@
       AND c.status = 'ONGOING'
       AND tc.cnt &lt; c.goal_cnt
   </select>
+  <update id="updateIsAchieved" parameterType="long">
+    UPDATE today_challenge SET is_achieved = true WHERE id = #{id}
+  </update>
 </mapper>

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/ChallegeServiceImplTest.java
@@ -50,7 +50,8 @@ public class ChallegeServiceImplTest {
                 mockChallenge.getId(),
                 10L,
                 1,
-                LocalDate.now()
+                LocalDate.now(),
+                true
         );
     }
 

--- a/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
+++ b/src/test/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImplTest.java
@@ -72,7 +72,7 @@ public class TodayChallengeServiceImplTest {
     @Test
     @DisplayName("오늘의 챌린지가 성공적으로 조회될 경우, 조회 결과를 반환한다.")
     void getTodayChallengeById_success() {
-        TodayChallenge todayChallenge = new TodayChallenge(1L, 10L, 1L, LocalDate.now());
+        TodayChallenge todayChallenge = new TodayChallenge(1L, 10L, 1L, LocalDate.now(), true);
         when(todayChallengeDao.selectTodayChallengeById(1L)).thenReturn(todayChallenge);
 
         TodayChallenge result = todayChallengeService.getTodayChallengeById(1L);
@@ -94,7 +94,7 @@ public class TodayChallengeServiceImplTest {
     @DisplayName("오늘의 챌린지를 달성할 경우, 경험치 5EXP를 추가한다.")
     void modifyTodayChallenge_getDailyExp() throws Exception {
         Challenge challenge = new Challenge(1L, "제목1",ChallengeStatus.ONGOING, ExerciseType.SQUAT, LocalDate.now().minusDays(100), LocalDate.now(), 10L, 0,1L);
-        TodayChallenge todayChallenge = new TodayChallenge(1L, 10L, 1L, LocalDate.now());
+        TodayChallenge todayChallenge = new TodayChallenge(1L, 10L, 1L, LocalDate.now(), true);
         TodayChallengeDto todayChallengeDto = new TodayChallengeDto(1L, 10L, 1L, LocalDate.now());
 
         when(todayChallengeDao.selectTodayChallengeById(todayChallengeDto.getId())).thenReturn(todayChallenge);
@@ -112,7 +112,7 @@ public class TodayChallengeServiceImplTest {
         Challenge challenge = new Challenge(1L, "제목1",ChallengeStatus.ONGOING, ExerciseType.SQUAT,
                 LocalDate.now().minusDays(100), LocalDate.now(), 10, 0, 1L);
         for (int i = 0; i < 7; i++) {
-            TodayChallenge todayChallenge = new TodayChallenge(i, 10, 1L, LocalDate.now().minusDays(i));
+            TodayChallenge todayChallenge = new TodayChallenge(i, 10, 1L, LocalDate.now().minusDays(i), true);
             when(todayChallengeDao.selectTodayChallengeById(todayChallenge.getId())).thenReturn(todayChallenge);
         }
         TodayChallengeDto todayChallengeDto = new TodayChallengeDto(0, 10, 1L, LocalDate.now());
@@ -132,7 +132,7 @@ public class TodayChallengeServiceImplTest {
         Challenge challenge = new Challenge(1L, "제목1",ChallengeStatus.ONGOING, ExerciseType.SQUAT,
                 LocalDate.now().minusDays(100), LocalDate.now(), 10L, 0, 1L);
         for (int i = 1; i <= 8; i++) {
-            TodayChallenge todayChallenge = new TodayChallenge(i, 10L, challenge.getId(), LocalDate.now().minusDays(i));
+            TodayChallenge todayChallenge = new TodayChallenge(i, 10L, challenge.getId(), LocalDate.now().minusDays(i), true);
             when(todayChallengeDao.selectTodayChallengeById(todayChallenge.getId())).thenReturn(todayChallenge);
         }
         TodayChallengeDto todayChallengeDto = new TodayChallengeDto(1L, 10L, challenge.getId(), LocalDate.now());
@@ -154,7 +154,7 @@ public class TodayChallengeServiceImplTest {
         Challenge challenge = new Challenge(1L, "제목1", ChallengeStatus.ONGOING, ExerciseType.SQUAT,
                 LocalDate.now().minusDays(100), LocalDate.now(), 10L, 0, 1L);
         for (int i = 0; i < 30; i++) {
-            TodayChallenge todayChallenge = new TodayChallenge(i, 10L, challenge.getId(), LocalDate.now().minusDays(i));
+            TodayChallenge todayChallenge = new TodayChallenge(i, 10L, challenge.getId(), LocalDate.now().minusDays(i), true);
             when(todayChallengeDao.selectTodayChallengeById(todayChallenge.getId())).thenReturn(todayChallenge);
         }
         TodayChallengeDto todayChallengeDto = new TodayChallengeDto(0, 10L, challenge.getId(), LocalDate.now());
@@ -175,7 +175,7 @@ public class TodayChallengeServiceImplTest {
     void modifyUnachievementTodayChallenge() throws Exception {
         LocalDate yesterday = LocalDate.now().minusDays(1);
         Challenge challenge = new Challenge(1L, "제목1",ChallengeStatus.ONGOING, ExerciseType.SQUAT, LocalDate.now(), LocalDate.now(), 10L, 0,1L);
-        TodayChallenge unachievedTodayChallenge = new TodayChallenge(1L, 5L, 1L, yesterday);
+        TodayChallenge unachievedTodayChallenge = new TodayChallenge(1L, 5L, 1L, yesterday, false);
 
         when(todayChallengeDao.findUnachievedChallenges(yesterday)).thenReturn(List.of(unachievedTodayChallenge));
         when(challengeService.getChallengeDetail(unachievedTodayChallenge.getChallengeId())).thenReturn(challenge);


### PR DESCRIPTION
## 연관된 이슈

> 

## 작업 내용

> 프론트엔드 메인 페이지 연동을 진행하면서 거기에 추가로 필요한 api와 데이터 필드를 추가하였습니다.
> - 추가 API 구현
>   - userId와 year, month를 이용하여 한 달 동안의 game 리스트를 조회하는 기능을 구현하였습니다.
>   - userId와 year, month를 이용하여 한 달 동안의 todayChallenge 리스트를 조회하는 기능을 구현하였습니다.
>   - userId와 date를 이용하여 하루 동안의 game 리스트를 조회하는 기능을 구현하였습니다.
>   - userId와 date를 이용하여 하루 동안의 todayChallenge 리스트를 조회하는 기능을 구현하였습니다.
> - 필드 추가
>   - todayChallenge에 isAchieved 필드를 추가하였고, 오늘의 챌린지 달성 시 isAchieved를 true로 처리하는 로직을 구현하였습니다.
> - CORS 설정
>   - user CORS 설정을 임시로 추가하였습니다.

( 연동을 추가하다가 필요한 api 를 추가하는 과정에서 pr 내용이 방대해졌습니다. 감안하여 봐주시기 바랍니다.. 🙏 )