### PR TITLE
 Tier 업데이트 로직 추가

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/dao/UserDao.java
@@ -1,10 +1,12 @@
 package com.him.fpjt.him_backend.user.dao;
 
+import com.him.fpjt.him_backend.user.domain.Tier;
 import com.him.fpjt.him_backend.user.domain.User;
 import java.util.List;
 
 public interface UserDao {
     int updateUserExp(long userId, long expPoints);
+    int updateUserTier(long userId, Tier tier);
     List<Long> selectAllUserIds();
     User selectUserById(long userId);
     User selectUserByEmail(String email);

--- a/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/service/UserServiceImpl.java
@@ -1,9 +1,11 @@
 package com.him.fpjt.him_backend.user.service;
 
 import com.him.fpjt.him_backend.user.dao.UserDao;
+import com.him.fpjt.him_backend.user.domain.Tier;
 import com.him.fpjt.him_backend.user.domain.User;
 import com.him.fpjt.him_backend.user.dto.UserInfoDto;
 import com.him.fpjt.him_backend.user.dto.UserModifyDto;
+import com.him.fpjt.him_backend.user.util.TierManager;
 import java.util.List;
 import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
@@ -24,6 +26,15 @@ public class UserServiceImpl implements UserService {
         int updateResult = userDao.updateUserExp(userId, expPoints);
         if (updateResult == 0) {
             throw new IllegalStateException("사용자 경험치 업데이트에 실패했습니다.");
+        }
+        User user = userDao.selectUserById(userId);
+        levelUpTier(user);
+    }
+
+    private void levelUpTier(User user) {
+        Tier currentTier = user.getTier();
+        if (user.getExp() >= TierManager.getRequiredExpForNextTier(currentTier)) {
+            userDao.updateUserTier(user.getId(), TierManager.getNextTier(currentTier));
         }
     }
 

--- a/src/main/java/com/him/fpjt/him_backend/user/util/TierManager.java
+++ b/src/main/java/com/him/fpjt/him_backend/user/util/TierManager.java
@@ -1,0 +1,34 @@
+package com.him.fpjt.him_backend.user.util;
+
+import com.him.fpjt.him_backend.user.domain.Tier;
+
+public class TierManager {
+    public static Tier getNextTier(Tier currentTier) {
+        switch (currentTier) {
+            case IRON: return Tier.BRONZE;
+            case BRONZE: return Tier.SILVER;
+            case SILVER: return Tier.GOLD;
+            case GOLD: return Tier.PLATINUM;
+            case PLATINUM: return Tier.EMERALD;
+            case EMERALD: return Tier.DIAMOND;
+            case DIAMOND: return Tier.MASTER;
+            case MASTER: return Tier.LEGEND;
+            case LEGEND: return Tier.GOAT;
+            default: return null;
+        }
+    }
+    public static int getRequiredExpForNextTier(Tier currentTier) {
+        switch (currentTier) {
+            case IRON: return 1000;
+            case BRONZE: return 2000;
+            case SILVER: return 3000;
+            case GOLD: return 4000;
+            case PLATINUM: return 5000;
+            case EMERALD: return 6000;
+            case DIAMOND: return 8000;
+            case MASTER: return 9000;
+            case LEGEND: return 10000;
+            default: return 0;
+        }
+    }
+}

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -9,6 +9,11 @@
         WHERE id = #{userId}
     </update>
 
+    <update id="updateUserTier" parameterType="map">
+        UPDATE user SET tier = #{tier}
+        WHERE id = #{userId}
+    </update>
+
     <select id="selectAllUserIds" resultType="long">
         SELECT id FROM user
     </select>


### PR DESCRIPTION
## 연관된 이슈

> 

## 작업 내용

> - 경험치 변경 시, 경험치가 다음 tier의 경험치를 달성하였다면 tier를 업데이트하는 로직을 추가하였습니다.
> - tierManager에서 다음 티어와 다음 티어에 도달하기 위한 경험치를 제공하는 로직을 구현하였습니다.
