### PR TITLE
인증 / 인가 처리 로직 에러 해결

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/auth/service/AuthServiceImpl.java
@@ -108,7 +108,6 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     @Override
     public void deleteRefreshTokenByEmail(String email) {
-        System.out.println("AuthServiceImpl: " + email);
         int rowsAffected = refreshTokenDao.deleteByUserEmail(email);
         if (rowsAffected == 0) {
             throw new IllegalStateException("해당 이메일에 대한 Refresh Token이 존재하지 않습니다.");
@@ -118,7 +117,6 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public User findUserByEmail(String email) {
         User user = userDao.selectUserByEmail(email);
-        System.out.println("AuthServiceImpl email: " + email);
         if (user == null) {
             throw new IllegalArgumentException("해당 이메일을 가진 사용자가 없습니다.");
         }

--- a/src/main/java/com/him/fpjt/him_backend/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/auth/service/AuthServiceImpl.java
@@ -139,7 +139,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Transactional
-    private void saveVerificationCode(VerificationCodeDto verificationCodeDto, String code) {
+    void saveVerificationCode(VerificationCodeDto verificationCodeDto, String code) {
         VerificationCode verificationCode = new VerificationCode(verificationCodeDto.getEmail(), code, LocalDateTime.now());
         int result = verificationCodeDao.insertVerificationCode(verificationCode);
         if (result == 0) {

--- a/src/main/java/com/him/fpjt/him_backend/common/config/CorsConfig.java
+++ b/src/main/java/com/him/fpjt/him_backend/common/config/CorsConfig.java
@@ -17,7 +17,8 @@ public class CorsConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(List.of("http://localhost:5173"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "New-Access-Token"));
+        configuration.addExposedHeader("New-Access-Token");
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/him/fpjt/him_backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/him/fpjt/him_backend/common/config/SecurityConfig.java
@@ -24,7 +24,6 @@ public class SecurityConfig {
     public SecurityConfig(JwtRequestFilter jwtRequestFilter, CorsConfig corsConfig){
         this.jwtRequestFilter = jwtRequestFilter;
         this.corsConfig = corsConfig;
-
     }
 
     @Bean
@@ -32,14 +31,13 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                                .requestMatchers("/api/auth/**").permitAll()
-                                .requestMatchers("/api/challenge/**").authenticated()
-                                .requestMatchers("/api/today-challenge/**").authenticated()
-                                .requestMatchers("/api/game/**").authenticated()
-                                .requestMatchers("/api/attendance/**").authenticated()
-                                .requestMatchers("/api/user/**").authenticated()
-                                .anyRequest().authenticated()
-//                        .anyRequest().permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/challenge/**").authenticated()
+                        .requestMatchers("/api/today-challenge/**").authenticated()
+                        .requestMatchers("/api/game/**").authenticated()
+                        .requestMatchers("/api/attendance/**").authenticated()
+                        .requestMatchers("/api/user/**").authenticated()
+                        .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/com/him/fpjt/him_backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/him/fpjt/him_backend/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.him.fpjt.him_backend.common.exception;
 
 import com.him.fpjt.him_backend.common.exception.dto.ExceptionDto;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.validation.ConstraintViolationException;
 import java.time.LocalDateTime;

--- a/src/main/java/com/him/fpjt/him_backend/common/filter/JwtRequestFilter.java
+++ b/src/main/java/com/him/fpjt/him_backend/common/filter/JwtRequestFilter.java
@@ -64,7 +64,6 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
             if (jwtUtil.isTokenExpired(jwt)) {
                 handleExpiredToken(response, email, userDetails, request);
-                return;
             }
             setAuthentication(userDetails, userId, request);
         }

--- a/src/main/java/com/him/fpjt/him_backend/common/filter/JwtRequestFilter.java
+++ b/src/main/java/com/him/fpjt/him_backend/common/filter/JwtRequestFilter.java
@@ -50,13 +50,13 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
         try {
             if (jwt != null) {
-                email = jwtUtil.extractEmail(jwt); // 이메일 추출
-                userId = jwtUtil.extractUserId(jwt); // userId 추출
+                email = jwtUtil.extractEmail(jwt);
+                userId = jwtUtil.extractUserId(jwt);
             }
         } catch (ExpiredJwtException e) {
             Claims claims = e.getClaims();
-            email = claims.getSubject(); // 만료된 토큰에서 이메일 추출
-            userId = claims.get("userId", Long.class); // 만료된 토큰에서 userId 추출
+            email = claims.getSubject();
+            userId = claims.get("userId", Long.class);
         }
 
         if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
@@ -66,9 +66,6 @@ public class JwtRequestFilter extends OncePerRequestFilter {
                 handleExpiredToken(response, email, userDetails, request);
                 return;
             }
-
-            System.out.println("넘어오나?");
-
             setAuthentication(userDetails, userId, request);
         }
 

--- a/src/main/java/com/him/fpjt/him_backend/common/util/JwtUtil.java
+++ b/src/main/java/com/him/fpjt/him_backend/common/util/JwtUtil.java
@@ -33,18 +33,8 @@ public class JwtUtil {
         this.refreshExpirationMs = refreshExpirationMs;
     }
 
-//    private Key getSigningKey() {
-//        return secretKey;
-//    }
-
     public String generateToken(String email, Long userId) {
         long currentTimeMillis = System.currentTimeMillis();
-        System.out.println("Generating Token:");
-        System.out.println("Current time millis: " + currentTimeMillis);
-        System.out.println("Email: " + email);
-        System.out.println("UserId: " + userId);
-
-        System.out.println("Token generation time: " + new Date(currentTimeMillis));
         return Jwts.builder()
                 .setHeaderParam("type", "access")
                 .setSubject(email)
@@ -71,7 +61,6 @@ public class JwtUtil {
         try {
             return extractClaim(token, claims -> claims.get("userId", Long.class));
         } catch (ExpiredJwtException e) {
-            // 만료된 토큰에서도 userId 추출
             return e.getClaims().get("userId", Long.class);
         }
     }
@@ -86,7 +75,6 @@ public class JwtUtil {
             Date expiration = extractExpiration(token);
             return expiration.before(new Date(System.currentTimeMillis()));
         } catch (ExpiredJwtException e) {
-            // 만료된 토큰인 경우 true 반환
             return true;
         }
     }
@@ -95,7 +83,6 @@ public class JwtUtil {
         try {
             return extractClaim(token, Claims::getExpiration);
         } catch (ExpiredJwtException e) {
-            // 만료된 토큰에서도 만료 시간을 반환
             return e.getClaims().getExpiration();
         }
     }

--- a/src/main/java/com/him/fpjt/him_backend/common/util/JwtUtil.java
+++ b/src/main/java/com/him/fpjt/him_backend/common/util/JwtUtil.java
@@ -51,7 +51,6 @@ public class JwtUtil {
                 .setHeaderParam("type", "refresh")
                 .setSubject(email)
                 .claim("userId", userId)
-                .setIssuedAt(new Date())
                 .setExpiration(new Date(currentTimeMillis + refreshExpirationMs))
                 .signWith(refreshSecretKey, SignatureAlgorithm.HS256)
                 .compact();

--- a/src/main/resources/mappers/RefreshTokenMapper.xml
+++ b/src/main/resources/mappers/RefreshTokenMapper.xml
@@ -13,6 +13,7 @@
         SELECT id, token, email, expiry_date
         FROM refresh_tokens
         WHERE email = #{email}
+        ORDER BY expiry_date DESC LIMIT 1
     </select>
 
     <delete id="deleteByUserEmail" parameterType="String">


### PR DESCRIPTION
## 연관된 이슈

> resolve #60 

## 작업 내용
> 인증/인가 처리 과정에서 발생하는 에러들을 해결하였습니다.
> 1. accessToken과 refreshToken 값이 동일한 문제 해결
> - 문제: 처음 로그인 시점에 두 토큰이 생성되면서 생성 시점과 사용자 데이터가 동일하여 두 토큰의 값이 동일하게 생성되는 문제가 발생하였습니다.
> - 해결: RefreshToken 도메인에 만료일 필드가 이미 존재하므로, RefreshToken 생성 시 만료일 데이터를 중복해서 포함하지 않도록 수정하였습니다. 이를 통해 AccessToken과 RefreshToken의 값이 동일하게 생성되는 문제를 해결하였습니다.

> 2. accessToken 재발급 후 클라이언트 요청이 정상적으로 처리되지 않는 문제 해결
> - 문제: AccessToken 재발급 후, JWTRequestFilter에서 토큰 발급 후 클라이언트 요청이 처리되지 않았습니다.
> - 해결: JWTRequestFilter에서 `return`문을 제거하여 클라이언트 요청이 정상적으로 처리되도록 수정하였습니다.

> 3. 재 생성된 accesstoken이 클라이언트 헤더에 전달되지 않는 문제 해결
> - 문제: 재발급된 AccessToken이 응답 헤더에 포함되지만, CORS 설정 부족으로 클라이언트에서 헤더 데이터를 읽지 못하는 문제가 발생하였습니다.
> - 해결: 응답 헤더에 토큰을 포함할 수 있도록 CORS 설정을 추가하여 문제를 해결하였습니다.
