### PR TITLE
챌린지 생성 및 챌린지 경험치 업데이트 로직 수정

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/controller/TodayChallengeController.java
@@ -6,7 +6,6 @@ import com.him.fpjt.him_backend.exercise.service.TodayChallengeService;
 import java.time.LocalDate;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/today-challenge")
-@CrossOrigin(origins = "http://localhost:5173")
 public class TodayChallengeController {
     private TodayChallengeService todayChallengeService;
 

--- a/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/dao/ChallengeDao.java
@@ -17,4 +17,5 @@ public interface ChallengeDao {
     public int updateChallengeStatus(LocalDate today);
     public int updateChallenge(Challenge challenge);
     public List<Long> selectAllChallengeId();
+    public Challenge selectChallengeByTitle(String title);
 }

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/ChallengeServiceImpl.java
@@ -1,8 +1,10 @@
 package com.him.fpjt.him_backend.exercise.service;
 
 import com.him.fpjt.him_backend.exercise.dao.ChallengeDao;
+import com.him.fpjt.him_backend.exercise.dao.TodayChallengeDao;
 import com.him.fpjt.him_backend.exercise.domain.Challenge;
 import com.him.fpjt.him_backend.exercise.domain.ChallengeStatus;
+import com.him.fpjt.him_backend.exercise.domain.TodayChallenge;
 import com.him.fpjt.him_backend.exercise.dto.ChallengeDto;
 import java.time.LocalDate;
 import java.util.List;
@@ -15,8 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ChallengeServiceImpl implements ChallengeService {
     private final ChallengeDao challengeDao;
-    public ChallengeServiceImpl(ChallengeDao challengeDao) {
+    private final TodayChallengeDao todayChallengeDao;
+
+    public ChallengeServiceImpl(ChallengeDao challengeDao, TodayChallengeDao todayChallengeDao) {
         this.challengeDao = challengeDao;
+        this.todayChallengeDao = todayChallengeDao;
     }
 
     @Override
@@ -26,6 +31,8 @@ public class ChallengeServiceImpl implements ChallengeService {
         if (result == 0) {
             throw new IllegalStateException("챌린지 저장에 실패했습니다.");
         }
+        Challenge savedChallenge = challengeDao.selectChallengeByTitle(challenge.getTitle());
+        todayChallengeDao.insertTodayChallenge(new TodayChallenge(0, savedChallenge.getId(), LocalDate.now(), false));
     }
 
     @Override

--- a/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
+++ b/src/main/java/com/him/fpjt/him_backend/exercise/service/TodayChallengeServiceImpl.java
@@ -87,7 +87,10 @@ public class TodayChallengeServiceImpl implements TodayChallengeService {
 
     private boolean isGoalAchieved(TodayChallenge todayChallenge) {
         long goalCnt = challengeService.getChallengeDetail(todayChallenge.getChallengeId()).getGoalCnt();
-        return todayChallenge.getCnt() >= goalCnt;
+        if (!todayChallenge.isAchieved() && todayChallenge.getCnt() >= goalCnt) {
+            return true;
+        }
+        return false;
     }
 
     private int calculateAchievementBonusExp(long challengeId, LocalDate currentDate) {

--- a/src/main/resources/mappers/ChallengeMapper.xml
+++ b/src/main/resources/mappers/ChallengeMapper.xml
@@ -62,4 +62,7 @@
     SET type = #{type}, start_dt = #{startDt}, end_dt = #{endDt}, goal_cnt = #{goalCnt}
     WHERE id = #{id}
   </update>
+  <select id="selectChallengeByTitle" resultType="Challenge">
+    SELECT * FROM challenge WHERE title = #{title}
+  </select>
 </mapper>


### PR DESCRIPTION
## 연관된 이슈

>

## 작업 내용

> - 챌린지 생성 시 오늘 날짜의 todaychallenge 생성하는 로직을 추가하였습니다.
> - 챌린지 경험치 업데이트 시, 한번 업데이트된 경우 경험치가 중복으로 업데이트 되는 경우를 방지하기 위해 조건을 수정하였습니다.

