### PR TITLE
fix : ssl 도입에 따른 cors allowed origin url 변경

### DIFF
--- a/src/main/java/com/him/fpjt/him_backend/common/config/CorsConfig.java
+++ b/src/main/java/com/him/fpjt/him_backend/common/config/CorsConfig.java
@@ -15,7 +15,7 @@ public class CorsConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:5173", "http://him-frontend-build.s3-website.ap-northeast-2.amazonaws.com"));
+        configuration.setAllowedOrigins(List.of("http://localhost:5173", "https://www.letsgethim.site", "http://www.letsgethim.site"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "New-Access-Token"));
         configuration.addExposedHeader("New-Access-Token");


### PR DESCRIPTION
## 연관된 이슈

> 

## 작업 내용

> ssl 도입에 따라 변경된 프론트엔드 url을 cors allowed origins 설정에 적용하고 기존 버킷 url을 제거하였습니다.
